### PR TITLE
Nav2 and simulation startup settings adjustments

### DIFF
--- a/vizzy_gazebo/launch/vizzy_sim_world_launch.xml
+++ b/vizzy_gazebo/launch/vizzy_sim_world_launch.xml
@@ -38,13 +38,6 @@
   <let if="$(var gui)" name="command_arg3" value=""/> <!-- Server only flag -->
   <let unless="$(var gui)" name="command_arg3" value="-s"/> <!-- Nothing to show gui -->
 
-  <!-- Set the full path for the 'ign' executable -->
-  <let unless="$(var debug)" name="script_type" value="/usr/bin/ign"/>
-  <let if="$(var debug)" name="script_type" value="debug"/>
-
-  <!-- set environment variables -->
-  <set_env name="OPTIRUN_LAUNCH_PREFIX" value=""/>
-
   <!-- Create nodes with previously declared arguments 
   * In ROS2, substitutions for arguments have the tag 'var'
   * instead of 'arg' -->
@@ -53,6 +46,14 @@
   <!-- The node tag was changed to include because we now use
   the gz_sim.launch.py launch file from the ros_gz_sim package
   which takes the given arguments and passes them to ign gazebo -->
+
+  <arg name="configure_for_nvidia" default="$(env VIZZY_USE_NVIDIA false)"/>
+
+  <group if="$(var configure_for_nvidia)">
+    <set_env name="__NV_PRIME_RENDER_OFFLOAD" value="1"/>
+    <set_env name="__GLX_VENDOR_LIBRARY_NAME" value="nvidia"/>
+    <set_env name="__EGL_VENDOR_LIBRARY_FILENAMES" value="/usr/share/glvnd/egl_vendor.d/10_nvidia.json"/>
+  </group>
 
   <!-- Build the string with all the arguments separated by spaces -->
   <let name="command_args" value="$(var command_arg1) $(var command_arg2) $(var command_arg3) $(var extra_gazebo_args) $(find-pkg-prefix vizzy_gazebo)/share/vizzy_gazebo/worlds/$(var world)"/>

--- a/vizzy_launch/CMakeLists.txt
+++ b/vizzy_launch/CMakeLists.txt
@@ -13,7 +13,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # Load ament_cmake and all dependencies required for this package.
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake REQUIRED
+  vizzy_description REQUIRED
+  vizzy_navigation REQUIRED
+  vizzy_gazebo REQUIRED
+)
 
 # Install the directories to be accessible via the package.
 install(

--- a/vizzy_launch/launch/vizzy_simulation_launch.xml
+++ b/vizzy_launch/launch/vizzy_simulation_launch.xml
@@ -16,7 +16,7 @@
   <!-- Robot base frame id -->
   <arg name="base_frame_id" default="base_footprint"/>
   <!-- Robot odometry frame id -->
-  <arg name="odom_frame_id" default="odom"/>
+  <arg name="odom_frame_id" default="odometry"/>
   <!-- Robot pose relative to the map -->
   <arg name="pose" default="-x 0.0 -y 0.0 -z 0.0 -R 0.0 -P 0.0 -Y 3.1415"/>
   <!-- Robot semantic description file -->

--- a/vizzy_launch/package.xml
+++ b/vizzy_launch/package.xml
@@ -28,6 +28,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>vizzy_description</exec_depend>
+  <exec_depend>vizzy_navigation</exec_depend>
+  <exec_depend>vizzy_gazebo</exec_depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <build_type>ament_cmake</build_type>

--- a/vizzy_navigation/config/nav2_configuration.yaml
+++ b/vizzy_navigation/config/nav2_configuration.yaml
@@ -1,5 +1,6 @@
 amcl:
   ros__parameters:
+    use_sim_time: True
     alpha1: 0.6
     alpha2: 0.0872
     alpha3: 0.2
@@ -19,7 +20,7 @@ amcl:
     recovery_alpha_slow: 0.005
     resample_interval: 1
     sigma_hit: 0.2
-    transform_tolerance: 0.5
+    transform_tolerance: 0.7
     update_min_a: 0.05
     update_min_d: 0.05
     z_hit: 0.95
@@ -154,7 +155,7 @@ controller_server:
       sim_time: 1.7
       linear_granularity: 0.05
       angular_granularity: 0.025
-      transform_tolerance: 0.2
+      transform_tolerance: 0.5
       xy_goal_tolerance: 0.25
       trans_stopped_velocity: 0.25
       short_circuit_trajectory_evaluation: True
@@ -259,7 +260,7 @@ global_costmap:
           observation_persistence: 0.0
 
         scan_rear:
-          topic: /nav_hokuyo_laser/front/scan
+          topic: /nav_hokuyo_laser/rear/scan
           max_obstacle_height: 2.0
           clearing: True
           marking: True
@@ -294,7 +295,7 @@ map_saver:
 
 planner_server:
   ros__parameters:
-    expected_planner_frequency: 20.0
+    expected_planner_frequency: 1.0
     use_sim_time: True
     planner_plugins: ["GridBased"]
     GridBased:
@@ -329,9 +330,9 @@ behavior_server:
       plugin: "nav2_behaviors/Wait"
     assisted_teleop:
       plugin: "nav2_behaviors/AssistedTeleop"
-    global_frame: odom
+    global_frame: odometry
     robot_base_frame: base_footprint
-    transform_tolerance: 0.1
+    transform_tolerance: 0.5
     use_sim_time: True
     simulate_ahead_time: 2.0
     max_rotational_vel: 0.6

--- a/vizzy_navigation/launch/navigation_launch.py
+++ b/vizzy_navigation/launch/navigation_launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
 
     use_sim_time_arg = DeclareLaunchArgument(
         'use_sim_time',
-        default_value='false',
+        default_value='true',
         description='Use simulation (Ign Gazebo) clock if true')
 
     params_file_arg = DeclareLaunchArgument(


### PR DESCRIPTION
Nav2 and simulation startup settings adjustments 
-

This commit belongs to the migration of the navigation stack of the Vizzy project to ROS2. Key changes include:

### Simulation Startup Default Options
- `vizzy_navigation` package, `navigation_launch.py` -> Changed the default value of "use_sim_time" from "false" to "true". 

### Odometry Frame Name Correction
- `vizzy_launch` package, `vizzy_simulation_launch.xml` -> Fixed the odometry frame name from "odom" to "odometry" as to match the rest of the project.

### Added Needed Dependencies
- `vizzy_launch` package, `CMakeLists.txt`, `package.xml` -> Added needed vizzy dependencies.

### Cleaned Code & Added NVIDIA Graphics Card Support
- `vizzy_gazebo` `vizzy_sim_world_launch.xml` -> Removed unecessary code and added environment configuration if the user is running the simulation in a system with a NVIDIA graphics card.

### Nav2 Settings Adjustments
- `vizzy_navigation` `nav2_configuration.yaml` -> Changed Nav2 settings for better performance:
  - Inserted the "use_sim_time: True" parameter in AMCL.
  - Increased the transform tolerance in AMCL from 0.5 to 0.7.
  - Increased the transform tolerance in the Controller Server from 0.2 to 0.5.
  - Corrected rear scan topic name in Global Costmap.
  - Decreased planner frequency in the Planner Server from 20Hz to 1Hz.
  - Corrected odometry frame name in the Behaviour Server from "odom" to "odometry" to match the rest of the project.
  - Increased the transform tolerance in the Behaviour Server from 0.1 to 0.5.
  
