### PR TITLE
Nav2 and simulation startup settings adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
-# vizzy2.0
-Vizzy robot repository - ROS2 support
+# Vizzy Humanoid Robot - ROS 2 Core Packages
+
+[![Ubuntu 22.04](https://img.shields.io/badge/Ubuntu-22.04%20LTS-orange)](https://releases.ubuntu.com/22.04/)
+[![ROS 2 Humble](https://img.shields.io/badge/ROS%202-Humble%20Hawksbill-blue)](https://docs.ros.org/en/humble/index.html)
+[![Gazebo Fortress](https://img.shields.io/badge/Gazebo-Fortress-blueviolet)](https://gazebosim.org/docs/fortress)
+
+**🚧 Under Active Development & Migration 🚧**
+
+**Please Note:** This repository contains the core packages for Vizzy, refactored for ROS 2 Humble. The migration from previous systems (ROS 1, YARP) is an ongoing process. While core simulation and basic functionalities are available, some features may still be under development or subject to change. We are actively working on completing the migration and will be posting regular updates. Your feedback and patience are appreciated!
+
+Welcome to the core ROS 2 package suite for the Vizzy humanoid robot platform, refactored for **Ubuntu 22.04** and **ROS 2 Humble Hawksbill**. This repository provides essential software for simulation, control, perception, and interaction with Vizzy using the ROS 2 framework and Ignition Gazebo Fortress.
+
+For automated system setup and installation of all dependencies, please use our dedicated installer: [**vizzy_install_2.0**](https://github.com/vislab-tecnico-lisboa/vizzy_install_2.0).
+
+![vizzy_grasping_ball](https://github.com/user-attachments/assets/b8942c91-66ad-4de3-8e03-234f22d924b6)
+
+## Overview
+
+This repository contains a focused set of ROS 2 packages necessary to simulate and interact with the Vizzy robot. The primary goal is to provide a streamlined experience for users working with Vizzy in a ROS 2 Humble environment. All YARP dependencies and older ROS 1 specific code from previous versions have been deprecated or not yet migrated.
+
+## Packages
+
+This repository currently includes the following core ROS 2 packages:
+
+* **`vizzy_launch`**: Contains primary launch files to bring up the Vizzy simulation, navigation stack, and other core functionalities. For most users, this is the main entry point.
+* **`vizzy_description`**: Holds Vizzy's robot description files (URDF, meshes, kinematics, visual data, etc.).
+* **`vizzy_gazebo`**: Provides launch files and configurations required to simulate Vizzy in the Ignition Gazebo Fortress environment.
+* **`vizzy_navigation`**: Contains launch files and configurations for deploying the ROS 2 Navigation Stack (Nav2) with Vizzy.
+* **`vizzy_msgs`**: Defines custom ROS 2 messages, services, and actions specific to Vizzy.
+
+## Prerequisites
+
+To use these packages, your system should meet the following requirements:
+
+* **Operating System:** Ubuntu 22.04 LTS (Jammy Jellyfish)
+* **ROS 2 Version:** Humble Hawksbill (Desktop Install)
+* **Gazebo Version:** Ignition Gazebo Fortress
+* **Essential Tools:** `git`, `colcon` (ROS 2 build tool), `rosdep`
+
+**Note:** For your convenience, all listed prerequisites are managed and installed by our dedicated installer.
+
+## Installation and Setup
+
+The recommended method for setting up your system and installing these Vizzy packages is by using the scripts provided in the [**vizzy_install_2.0**](https://github.com/vislab-tecnico-lisboa/vizzy_install_2.0) repository.
+
+The installer script will:
+1.  Guide you through system dependencies installation (ROS 2 Humble, Gazebo Fortress, etc.).
+2.  Ask for your preferences (e.g., NVIDIA GPU usage for Gazebo, colcon workspace location).
+3.  Clone this `vizzy2.0` repository (containing these ROS 2 packages) into the specified colcon workspace (default: `~/vizzy2_ws/src/`).
+4.  Use `rosdep` to install package dependencies.
+5.  Build the colcon workspace.
+6.  Configure your `.bashrc` to source ROS 2 and the Vizzy workspace.
+
+**Please refer to the `README.md` in the [vizzy_install_2.0 repository](https://github.com/vislab-tecnico-lisboa/vizzy_install_2.0) for detailed installation instructions.**
+
+After running the installer and sourcing your `~/.bashrc` (or opening a new terminal), your environment should be ready.
+
+## Running the Simulation
+
+Once your environment is set up using the `vizzy_install_2.0` scripts:
+
+1.  **Ensure your shell environment is updated:**
+    If you haven't already, open a new terminal or run:
+    ```bash
+    source ~/.bashrc
+    ```
+
+2.  **Launch the main Vizzy simulation:**
+    This typically includes Gazebo, Nav2, and RViz2.
+    ```bash
+    ros2 launch vizzy_launch vizzy_simulation_launch.xml
+    ```
+    * **NVIDIA GPU Offloading:** If you opted for NVIDIA GPU usage during the installation via `vizzy_install_2.0`, the launch file should automatically attempt to use your NVIDIA GPU.
+    * The `vizzy_install_2.0` script also provides an alias `ign-nvidia` for manual Gazebo launching with NVIDIA offloading if needed for non-ROS 2 launch scenarios.
+
+## Documentation & Citation
+
+For more details on the Vizzy platform, please refer to the following publication:
+
+```bibtex
+@inproceedings{moreno2016vizzy,
+  title={Vizzy: A humanoid on wheels for assistive robotics},
+  author={Moreno, Plinio and Nunes, Ricardo and Figueiredo, Rui and Ferreira, Ricardo and Bernardino, Alexandre and Santos-Victor, Jos{\'e} and Beira, Ricardo and Vargas, Lu{\'\i}s and Arag{\~a}o, Duarte and Arag{\~a}o, Miguel},
+  booktitle={Robot 2015: Second Iberian Robotics Conference},
+  pages={17--28},
+  year={2016},
+  organization={Springer}
+}
+```
+
+## Reporting Issues
+
+Please report any bugs, issues, or feature requests related to these ROS 2 packages using the [GitHub Issues tab](https://github.com/vislab-tecnico-lisboa/vizzy2.0/issues) of this repository.
+
+For issues related to the system installation process, please use the issue tracker of the [vizzy_install_2.0 repository](https://github.com/vislab-tecnico-lisboa/vizzy_install_2.0/issues).

--- a/vizzy_gazebo/launch/vizzy_sim_world_launch.xml
+++ b/vizzy_gazebo/launch/vizzy_sim_world_launch.xml
@@ -38,13 +38,6 @@
   <let if="$(var gui)" name="command_arg3" value=""/> <!-- Server only flag -->
   <let unless="$(var gui)" name="command_arg3" value="-s"/> <!-- Nothing to show gui -->
 
-  <!-- Set the full path for the 'ign' executable -->
-  <let unless="$(var debug)" name="script_type" value="/usr/bin/ign"/>
-  <let if="$(var debug)" name="script_type" value="debug"/>
-
-  <!-- set environment variables -->
-  <set_env name="OPTIRUN_LAUNCH_PREFIX" value=""/>
-
   <!-- Create nodes with previously declared arguments 
   * In ROS2, substitutions for arguments have the tag 'var'
   * instead of 'arg' -->
@@ -53,6 +46,14 @@
   <!-- The node tag was changed to include because we now use
   the gz_sim.launch.py launch file from the ros_gz_sim package
   which takes the given arguments and passes them to ign gazebo -->
+
+  <arg name="configure_for_nvidia" default="$(env VIZZY_USE_NVIDIA false)"/>
+
+  <group if="$(var configure_for_nvidia)">
+    <set_env name="__NV_PRIME_RENDER_OFFLOAD" value="1"/>
+    <set_env name="__GLX_VENDOR_LIBRARY_NAME" value="nvidia"/>
+    <set_env name="__EGL_VENDOR_LIBRARY_FILENAMES" value="/usr/share/glvnd/egl_vendor.d/10_nvidia.json"/>
+  </group>
 
   <!-- Build the string with all the arguments separated by spaces -->
   <let name="command_args" value="$(var command_arg1) $(var command_arg2) $(var command_arg3) $(var extra_gazebo_args) $(find-pkg-prefix vizzy_gazebo)/share/vizzy_gazebo/worlds/$(var world)"/>

--- a/vizzy_gazebo/launch/vizzy_sim_world_launch.xml
+++ b/vizzy_gazebo/launch/vizzy_sim_world_launch.xml
@@ -31,34 +31,37 @@
   <arg name="world_pkg" default="$(find-pkg-prefix vizzy_gazebo)"/>
 
   <!-- set command arguments -->
-  <let if="$(var paused)" name="command_arg1" value=""/> <!-- Unpause the simulation as soon as it loads -->
-  <let unless="$(var paused)" name="command_arg1" value="-r"/> <!-- Nothing for the simulation to load in a paused state -->
-  <let if="$(var verbose)" name="command_arg2" value="-v4"/> <!-- Activate maximum verbose logging -->
-  <let unless="$(var verbose)" name="command_arg2" value=""/> <!-- Nothing for normal logging -->
-  <let if="$(var gui)" name="command_arg3" value=""/> <!-- Server only flag -->
-  <let unless="$(var gui)" name="command_arg3" value="-s"/> <!-- Nothing to show gui -->
+  <let if="$(var paused)" name="command_arg1" value=""/> <!-- Unpause the simulation as soon as it loads. -->
+  <let unless="$(var paused)" name="command_arg1" value="-r"/> <!-- Nothing for the simulation to load in a paused state. -->
+  <let if="$(var verbose)" name="command_arg2" value="-v4"/> <!-- Activate maximum verbose logging. -->
+  <let unless="$(var verbose)" name="command_arg2" value=""/> <!-- Nothing for normal logging. -->
+  <let if="$(var gui)" name="command_arg3" value=""/> <!-- Server only flag. -->
+  <let unless="$(var gui)" name="command_arg3" value="-s"/> <!-- Nothing to show gui. -->
 
-  <!-- Create nodes with previously declared arguments 
+  <!-- Create nodes with previously declared arguments. 
   * In ROS2, substitutions for arguments have the tag 'var'
-  * instead of 'arg' -->
+  * instead of 'arg'. -->
 
   <!-- Start gazebo -->
   <!-- The node tag was changed to include because we now use
   the gz_sim.launch.py launch file from the ros_gz_sim package
-  which takes the given arguments and passes them to ign gazebo -->
+  which takes the given arguments and passes them to ign gazebo. -->
 
   <arg name="configure_for_nvidia" default="$(env VIZZY_USE_NVIDIA false)"/>
 
-  <group if="$(var configure_for_nvidia)">
-    <set_env name="__NV_PRIME_RENDER_OFFLOAD" value="1"/>
-    <set_env name="__GLX_VENDOR_LIBRARY_NAME" value="nvidia"/>
-    <set_env name="__EGL_VENDOR_LIBRARY_FILENAMES" value="/usr/share/glvnd/egl_vendor.d/10_nvidia.json"/>
-  </group>
+  <set_env name="__NV_PRIME_RENDER_OFFLOAD" value="1" if="$(var configure_for_nvidia)"/>
+  <set_env name="__GLX_VENDOR_LIBRARY_NAME" value="nvidia" if="$(var configure_for_nvidia)"/>
+  <set_env name="__EGL_VENDOR_LIBRARY_FILENAMES" value="/usr/share/glvnd/egl_vendor.d/10_nvidia.json" if="$(var configure_for_nvidia)"/>
 
-  <!-- Build the string with all the arguments separated by spaces -->
+  <!-- Log the environment variables set for NVIDIA GPU Support. -->
+  <log message="Environment variables set for NVIDIA GPU support: __NV_PRIME_RENDER_OFFLOAD=$(env __NV_PRIME_RENDER_OFFLOAD)"/>
+  <log message="Environment variables set for NVIDIA GPU support: __GLX_VENDOR_LIBRARY_NAME=$(env __GLX_VENDOR_LIBRARY_NAME)"/>
+  <log message="Environment variables set for NVIDIA GPU support: __EGL_VENDOR_LIBRARY_FILENAMES=$(env __EGL_VENDOR_LIBRARY_FILENAMES)"/>
+
+  <!-- Build the string with all the arguments separated by spaces. -->
   <let name="command_args" value="$(var command_arg1) $(var command_arg2) $(var command_arg3) $(var extra_gazebo_args) $(find-pkg-prefix vizzy_gazebo)/share/vizzy_gazebo/worlds/$(var world)"/>
   <!-- The command_args variable is passed to the gz_sim.launch.py file
-  as an argument. The gz_sim.launch.py file will then pass it to the ign executable -->
+  as an argument. The gz_sim.launch.py file will then pass it to the ign executable. -->
   <include file="$(find-pkg-share ros_gz_sim)/launch/gz_sim.launch.py">
     <arg name="gz_args" value="$(var command_args)"/>
   </include>

--- a/vizzy_launch/CMakeLists.txt
+++ b/vizzy_launch/CMakeLists.txt
@@ -13,7 +13,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # Load ament_cmake and all dependencies required for this package.
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake REQUIRED
+  vizzy_description REQUIRED
+  vizzy_navigation REQUIRED
+  vizzy_gazebo REQUIRED
+)
 
 # Install the directories to be accessible via the package.
 install(

--- a/vizzy_launch/launch/vizzy_simulation_launch.xml
+++ b/vizzy_launch/launch/vizzy_simulation_launch.xml
@@ -16,7 +16,7 @@
   <!-- Robot base frame id -->
   <arg name="base_frame_id" default="base_footprint"/>
   <!-- Robot odometry frame id -->
-  <arg name="odom_frame_id" default="odom"/>
+  <arg name="odom_frame_id" default="odometry"/>
   <!-- Robot pose relative to the map -->
   <arg name="pose" default="-x 0.0 -y 0.0 -z 0.0 -R 0.0 -P 0.0 -Y 3.1415"/>
   <!-- Robot semantic description file -->

--- a/vizzy_launch/package.xml
+++ b/vizzy_launch/package.xml
@@ -28,6 +28,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>vizzy_description</exec_depend>
+  <exec_depend>vizzy_navigation</exec_depend>
+  <exec_depend>vizzy_gazebo</exec_depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <build_type>ament_cmake</build_type>

--- a/vizzy_navigation/config/nav2_configuration.yaml
+++ b/vizzy_navigation/config/nav2_configuration.yaml
@@ -1,5 +1,6 @@
 amcl:
   ros__parameters:
+    use_sim_time: True
     alpha1: 0.6
     alpha2: 0.0872
     alpha3: 0.2
@@ -19,7 +20,7 @@ amcl:
     recovery_alpha_slow: 0.005
     resample_interval: 1
     sigma_hit: 0.2
-    transform_tolerance: 0.5
+    transform_tolerance: 0.7
     update_min_a: 0.05
     update_min_d: 0.05
     z_hit: 0.95
@@ -154,7 +155,7 @@ controller_server:
       sim_time: 1.7
       linear_granularity: 0.05
       angular_granularity: 0.025
-      transform_tolerance: 0.2
+      transform_tolerance: 0.5
       xy_goal_tolerance: 0.25
       trans_stopped_velocity: 0.25
       short_circuit_trajectory_evaluation: True
@@ -259,7 +260,7 @@ global_costmap:
           observation_persistence: 0.0
 
         scan_rear:
-          topic: /nav_hokuyo_laser/front/scan
+          topic: /nav_hokuyo_laser/rear/scan
           max_obstacle_height: 2.0
           clearing: True
           marking: True
@@ -294,7 +295,7 @@ map_saver:
 
 planner_server:
   ros__parameters:
-    expected_planner_frequency: 20.0
+    expected_planner_frequency: 1.0
     use_sim_time: True
     planner_plugins: ["GridBased"]
     GridBased:
@@ -329,9 +330,9 @@ behavior_server:
       plugin: "nav2_behaviors/Wait"
     assisted_teleop:
       plugin: "nav2_behaviors/AssistedTeleop"
-    global_frame: odom
+    global_frame: odometry
     robot_base_frame: base_footprint
-    transform_tolerance: 0.1
+    transform_tolerance: 0.5
     use_sim_time: True
     simulate_ahead_time: 2.0
     max_rotational_vel: 0.6

--- a/vizzy_navigation/launch/navigation_launch.py
+++ b/vizzy_navigation/launch/navigation_launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
 
     use_sim_time_arg = DeclareLaunchArgument(
         'use_sim_time',
-        default_value='false',
+        default_value='true',
         description='Use simulation (Ign Gazebo) clock if true')
 
     params_file_arg = DeclareLaunchArgument(


### PR DESCRIPTION
Nav2 and simulation startup settings adjustments 
-

This commit belongs to the migration of the navigation stack of the Vizzy project to ROS2. Key changes include:

### Simulation Startup Default Options
- `vizzy_navigation` package, `navigation_launch.py` -> Changed the default value of "use_sim_time" from "false" to "true". 

### Odometry Frame Name Correction
- `vizzy_launch` package, `vizzy_simulation_launch.xml` -> Fixed the odometry frame name from "odom" to "odometry" as to match the rest of the project.

### Added Needed Dependencies
- `vizzy_launch` package, `CMakeLists.txt`, `package.xml` -> Added needed vizzy dependencies.

### Cleaned Code & Added NVIDIA Graphics Card Support
- `vizzy_gazebo` `vizzy_sim_world_launch.xml` -> Removed unecessary code and added environment configuration if the user is running the simulation in a system with a NVIDIA graphics card. **(Corrected bug of limited scope for the setup of the necessary environment variables.)**

### Nav2 Settings Adjustments
- `vizzy_navigation` `nav2_configuration.yaml` -> Changed Nav2 settings for better performance:
  - Inserted the "use_sim_time: True" parameter in AMCL.
  - Increased the transform tolerance in AMCL from 0.5 to 0.7.
  - Increased the transform tolerance in the Controller Server from 0.2 to 0.5.
  - Corrected rear scan topic name in Global Costmap.
  - Decreased planner frequency in the Planner Server from 20Hz to 1Hz.
  - Corrected odometry frame name in the Behaviour Server from "odom" to "odometry" to match the rest of the project.
  - Increased the transform tolerance in the Behaviour Server from 0.1 to 0.5.