### PR TITLE
 Kokam Battery Service: ROS1 -> ROS2 migration with serial resilience and charging state hysteresis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vizzy_navigation/script/*.py  text eol=lf

--- a/README.md
+++ b/README.md
@@ -320,13 +320,12 @@ For those to whom this may concern, we leave here a setup tutorial for the real 
     colcon build --symlink-install
     ```
 8.  **Final Details**
-    Once (and if) everything is correctly built, we can safely ignore the nav2, segway drivers and TEASER++ packages in future builds and remove the ignore command on our main vizzy2 folder.
+    Once (and if) everything is correctly built, we can safely ignore the nav2 and segway drivers packages in future builds and remove the ignore command on our main vizzy2 folder.
     ```bash
     rm src/vizzy2/COLCON_IGNORE
     touch src/navigation2/COLCON_IGNORE
     touch src/libsegwayrmp_ros2/COLCON_IGNORE
     touch src/segway_rmp_ros2/COLCON_IGNORE
-    touch src/TEASER-plusplus/COLCON_IGNORE
     ```
 
 For more information regarding this version of nav2, please refer to [their official repository](https://github.com/ros-navigation/navigation2/tree/humble_main).

--- a/README.md
+++ b/README.md
@@ -292,31 +292,21 @@ For those to whom this may concern, we leave here a setup tutorial for the real 
     cd ~/vizzy2/vizzy2_ws/src/
     git clone https://github.com/ros-navigation/navigation2.git --branch humble_main
     ```
-4.  **Clone and Build the TEASER++ Repository**
-      ```bash
-      git clone https://github.com/MIT-SPARK/TEASER-plusplus.git
-      cd TEASER-plusplus
-      mkdir build
-      cd build
-      cmake ..
-      make -j$(nproc)
-      sudo make install
-      ```
 
-5.  **Install the ROS2 Dependencies**
+4.  **Install the ROS2 Dependencies**
     Use rosdep to install the necessary dependencies while disregarding dev packages.
     ```bash
     cd ..
     rosdep install -i --from-path src --rosdistro humble -y --skip-keys "nav2_minimal_tb3_sim nav2_minimal_tb4_sim"
     ```
-6.  **Remove Apt-Installed Dependencies**
+5.  **Remove Apt-Installed Dependencies**
     Sometimes rosdep installs dependencies from packages that are present in the source folder (ignoring the -i command). For this,
      we need to manually remove any installed nav2 dependence.
     ```bash
     sudo apt remove "ros-humble-nav2-*"
     rm -rf build/ install/ log/
     ```
-7.  **Tell Colcon to Ignore Certain Packages**
+6.  **Tell Colcon to Ignore Certain Packages**
     Because we want to focus just on nav2 now, let us ignore all the other packages.
     ```bash
     touch src/navigation2/nav2_system_tests/COLCON_IGNORE
@@ -324,12 +314,12 @@ For those to whom this may concern, we leave here a setup tutorial for the real 
     touch src/navigation2/segway_rmp_ros2/COLCON_IGNORE
     touch src/navigation2/libsegway_rmp_ros2/COLCON_IGNORE
     ```
-8.  **Build the Package**
+7.  **Build the Package**
     Let us build everything.
     ```bash
     colcon build --symlink-install
     ```
-9.  **Final Details**
+8.  **Final Details**
     Once (and if) everything is correctly built, we can safely ignore the nav2, segway drivers and TEASER++ packages in future builds and remove the ignore command on our main vizzy2 folder.
     ```bash
     rm src/vizzy2/COLCON_IGNORE

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The Vizzy stack launch can be configured using a wide range of launch arguments,
 | `log_level_segway` | `info` | Log level for `segway_rmp_ros2`. |
 | `autostart` | `true` | Whether to autostart the navigation stack. |
 | `use_respawn` | `false` | Whether to respawn the navigation nodes if they crash. |
+| `inter_cycle_delay` | `0.0` | Idle gap between query cycles (seconds) for kokam battery service. |
 
 ---
 
@@ -332,7 +333,7 @@ For more information regarding this version of nav2, please refer to [their offi
 
 At the end of the setup, you should have something that looks exactly like this:
 
-<img width="615" height="172" alt="Screenshot from 2025-09-23 07-01-26" src="https://github.com/user-attachments/assets/fa38f9b9-2063-4d99-8bc8-8692d848b928" />
+<img width="814" height="146" alt="image" src="https://github.com/user-attachments/assets/2139c6f6-988b-4db7-8cff-1d6c9ba6f06b" />
 
 ## Documentation & Citation
 

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -81,7 +81,7 @@
   <arg name="mppi_batch_size" default="2000" description="Count of randomly sampled candidate trajectories from current optimal control sequence in a given iteration."/>
   <arg name="mppi_vx_std" default="0.3" description="Standard deviation for linear velocity in the MPPI controller."/>
   <arg name="mppi_wz_std" default="0.2" description="Standard deviation for the general MPPI controller"/>
-  <arg name="mppi_vx_max" default="0.7" description="Maximum linear velocity in the MPPI controller."/>
+  <arg name="mppi_vx_max" default="0.5" description="Maximum linear velocity in the MPPI controller."/>
   <arg name="mppi_temperature" default="0.3" description="Selectiveness of trajectories by their costs."/>
   <arg name="mppi_iteration_count" default="1" description="Iteration count in the MPPI algorithm. Recommended to remain as 1 and instead prefer larger batch sizes."/>
   <arg name="mppi_constraint_critic_cost_weight" default="4.0" description="Cost weight for the MPPI constraint critic."/>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -86,7 +86,6 @@
   <arg name="mppi_iteration_count" default="1" description="Iteration count in the MPPI algorithm. Recommended to remain as 1 and instead prefer larger batch sizes."/>
   <arg name="mppi_constraint_critic_cost_weight" default="4.0" description="Cost weight for the MPPI constraint critic."/>
 
-  <arg name="staging_pose" default="-x -1.0 -y 0.0 -Y 0.0" description="Staging pose of the robot in the map frame for docking. Format: 'x y Yaw'"/>
   <arg name="always_send_full_costmap" default="false" description="Whether to always send the full costmap to the controller."/>
   <arg name="transform_tolerance" default="0.1" description="Transform tolerance for the navigation stack."/>
 
@@ -103,6 +102,9 @@
   <arg name="log_level_segway" default="info" description="Log level for segway_rmp_ros2."/>
 
   <arg name="inter_cycle_delay" default="0.0" description="Idle gap between query cycles (seconds) for kokam battery service."/>
+
+  <arg name="staging_pose_simulation" default="-x -1.0 -y 0.0 -Y 0.0" description="Simulated dock pose in the format 'x y Yaw' for testing the docking procedure in simulation."/>
+  <arg name="staging_pose_real" default="-x -1.0 -y 0.0 -Y 0.0" description="Real dock pose in the format 'x y Yaw' for the docking procedure with the real robot."/>
 
   <!-- Launch the laser filters -->
   <group if="$(var use_laser_filters)">
@@ -195,11 +197,12 @@
           <arg name="mppi_temperature" value="$(var mppi_temperature)"/>
           <arg name="mppi_iteration_count" value="$(var mppi_iteration_count)"/>
           <arg name="mppi_constraint_critic_cost_weight" value="$(var mppi_constraint_critic_cost_weight)"/>
-          <arg name="staging_pose" value="$(var staging_pose)"/>
           <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
           <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
           <arg name="use_patrol" value="$(var use_patrol)"/>
           <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
+          <arg name="staging_pose_simulation" value="$(var staging_pose_simulation)"/>
+          <arg name="staging_pose_real" value="$(var staging_pose_real)"/>
         </include>
       </group>
       <group unless="$(var use_obstacles)">
@@ -263,11 +266,12 @@
           <arg name="mppi_temperature" value="$(var mppi_temperature)"/>
           <arg name="mppi_iteration_count" value="$(var mppi_iteration_count)"/>
           <arg name="mppi_constraint_critic_cost_weight" value="$(var mppi_constraint_critic_cost_weight)"/>
-          <arg name="staging_pose" value="$(var staging_pose)"/>
           <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
           <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
           <arg name="use_patrol" value="$(var use_patrol)"/>
           <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
+          <arg name="staging_pose_simulation" value="$(var staging_pose_simulation)"/>
+          <arg name="staging_pose_real" value="$(var staging_pose_real)"/>
         </include>
       </group>
     </group>
@@ -355,11 +359,12 @@
           <arg name="mppi_temperature" value="$(var mppi_temperature)"/>
           <arg name="mppi_iteration_count" value="$(var mppi_iteration_count)"/>
           <arg name="mppi_constraint_critic_cost_weight" value="$(var mppi_constraint_critic_cost_weight)"/>
-          <arg name="staging_pose" value="$(var staging_pose)"/>
           <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
           <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
           <arg name="use_patrol" value="$(var use_patrol)"/>
           <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
+          <arg name="staging_pose_simulation" value="$(var staging_pose_simulation)"/>
+          <arg name="staging_pose_real" value="$(var staging_pose_real)"/>
         </include>
       </group>
       <group unless="$(var use_obstacles)">
@@ -423,11 +428,12 @@
           <arg name="mppi_temperature" value="$(var mppi_temperature)"/>
           <arg name="mppi_iteration_count" value="$(var mppi_iteration_count)"/>
           <arg name="mppi_constraint_critic_cost_weight" value="$(var mppi_constraint_critic_cost_weight)"/>
-          <arg name="staging_pose" value="$(var staging_pose)"/>
           <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
           <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
           <arg name="use_patrol" value="$(var use_patrol)"/>
           <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
+          <arg name="staging_pose_simulation" value="$(var staging_pose_simulation)"/>
+          <arg name="staging_pose_real" value="$(var staging_pose_real)"/>
         </include>
       </group>
     </group>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -33,8 +33,8 @@
   <arg name="obstacles_map_yaml" default="$(find-pkg-share vizzy_navigation)/maps/$(var obstacles_map_file)" description="Path to the obstacles map YAML file"/>
   <arg name="laser_filter_params_file" default="$(find-pkg-share vizzy_sensors)/config/hokuyo_filters.yaml" description="Path to the laser filters parameters file"/>
   <arg name="map_frame_id" default="map" description="Frame id for the map"/>
-  <arg name="update_min_d" default="0.01" description="Minimum distance for localization updates"/>
-  <arg name="update_min_a" default="0.01" description="Minimum angle for localization updates"/>
+  <arg name="update_min_d" default="0.2" description="Minimum distance for localization updates"/>
+  <arg name="update_min_a" default="0.2" description="Minimum angle for localization updates"/>
   <arg name="laser_max_range" default="-1.0" description="Maximum range for the laser scanner"/>
   <arg name="beam_skip_distance" default="0.5" description="Distance threshold for beam skipping"/>
   <arg name="beam_skip_error_threshold" default="0.9" description="Error threshold for beam skipping"/>
@@ -53,7 +53,7 @@
   <arg name="cost_scaling_factor" default="3.0" description="Cost scaling factor for the inflation layer in the costmap"/>
   <arg name="base_obstacle_scale" default="0.02" description="Base obstacle scale for the costmap. This is used by the local and global costmaps to scale the cost of obstacles."/>
   <arg name="controller_plugin_type" default="MPPI" description="Type of controller plugin to use. Options: DWB, RPP, MPPI"/>
-  <arg name="expected_planner_frequency" default="1.0" description="Expected frequency of the planner in Hz"/>
+  <arg name="expected_planner_frequency" default="0.2" description="Expected frequency of the planner in Hz"/>
   <arg name="planner_plugin_type" default="ThetaStar" description="Planner plugin to use for the navigation stack"/>
   <arg name="robot_radius" default="0.4" description="Robot radius for the navigation stack. This is used by the local and global costmaps to scale the cost of obstacles."/>
   <arg name="mppi_wide_cost_critic_cost_weight" default="3.82" description="Cost weight for the wide MPPI cost critic"/>
@@ -76,7 +76,7 @@
 
   <!-- General MPPI Controller Parameters -->
   <arg name="mppi_cost_critic_cost_weight" default="1.5" description="Cost weight for the general MPPI cost critic"/>
-  <arg name="mppi_path_align_critic_cost_weight" default="20.0" description="Cost weight for the general MPPI path align critic"/>
+  <arg name="mppi_path_align_critic_cost_weight" default="10.0" description="Cost weight for the general MPPI path align critic"/>
   <arg name="mppi_time_steps" default="64" description="Number of time steps (points) in candidate trajectories."/>
   <arg name="mppi_batch_size" default="2000" description="Count of randomly sampled candidate trajectories from current optimal control sequence in a given iteration."/>
   <arg name="mppi_vx_std" default="0.3" description="Standard deviation for linear velocity in the MPPI controller."/>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -104,7 +104,7 @@
   <arg name="inter_cycle_delay" default="0.0" description="Idle gap between query cycles (seconds) for kokam battery service."/>
 
   <arg name="staging_pose_simulation" default="-x -1.0 -y 0.0 -Y 0.0" description="Simulated dock pose in the format 'x y Yaw' for testing the docking procedure in simulation."/>
-  <arg name="staging_pose_real" default="-x -1.0 -y 0.0 -Y 0.0" description="Real dock pose in the format 'x y Yaw' for the docking procedure with the real robot."/>
+  <arg name="staging_pose_real" default="-x -5.132 -y -5.142 -Y -0.111" description="Real dock pose in the format 'x y Yaw' for the docking procedure with the real robot."/>
 
   <!-- Launch the laser filters -->
   <group if="$(var use_laser_filters)">

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -81,7 +81,7 @@
   <arg name="mppi_batch_size" default="2000" description="Count of randomly sampled candidate trajectories from current optimal control sequence in a given iteration."/>
   <arg name="mppi_vx_std" default="0.3" description="Standard deviation for linear velocity in the MPPI controller."/>
   <arg name="mppi_wz_std" default="0.2" description="Standard deviation for the general MPPI controller"/>
-  <arg name="mppi_vx_max" default="1.0" description="Maximum linear velocity in the MPPI controller."/>
+  <arg name="mppi_vx_max" default="0.7" description="Maximum linear velocity in the MPPI controller."/>
   <arg name="mppi_temperature" default="0.3" description="Selectiveness of trajectories by their costs."/>
   <arg name="mppi_iteration_count" default="1" description="Iteration count in the MPPI algorithm. Recommended to remain as 1 and instead prefer larger batch sizes."/>
   <arg name="mppi_constraint_critic_cost_weight" default="4.0" description="Cost weight for the MPPI constraint critic."/>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -33,8 +33,8 @@
   <arg name="obstacles_map_yaml" default="$(find-pkg-share vizzy_navigation)/maps/$(var obstacles_map_file)" description="Path to the obstacles map YAML file"/>
   <arg name="laser_filter_params_file" default="$(find-pkg-share vizzy_sensors)/config/hokuyo_filters.yaml" description="Path to the laser filters parameters file"/>
   <arg name="map_frame_id" default="map" description="Frame id for the map"/>
-  <arg name="update_min_d" default="0.2" description="Minimum distance for localization updates"/>
-  <arg name="update_min_a" default="0.2" description="Minimum angle for localization updates"/>
+  <arg name="update_min_d" default="0.01" description="Minimum distance for localization updates"/>
+  <arg name="update_min_a" default="0.01" description="Minimum angle for localization updates"/>
   <arg name="laser_max_range" default="-1.0" description="Maximum range for the laser scanner"/>
   <arg name="beam_skip_distance" default="0.5" description="Distance threshold for beam skipping"/>
   <arg name="beam_skip_error_threshold" default="0.9" description="Error threshold for beam skipping"/>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -91,13 +91,15 @@
   <arg name="transform_tolerance" default="0.1" description="Transform tolerance for the navigation stack."/>
   
   <!-- Both lasers have the same angle_min and angle_max specifications. -->
-  <arg name="angle_min" default="-1.309" description="Minimum angle for the laser scanner"/>
-  <arg name="angle_max" default="1.309" description="Maximum angle for the laser scanner"/>
+  <arg name="angle_min" default="-1.309" description="Minimum angle for the laser scanner."/>
+  <arg name="angle_max" default="1.309" description="Maximum angle for the laser scanner."/>
 
-  <arg name="linear_vel_scale" default="false" description="Apply scale factor for linear velocity commands"/>
-  <arg name="angular_vel_scale" default="false" description="Apply scale factor for angular velocity commands"/>
+  <arg name="linear_vel_scale" default="false" description="Apply scale factor for linear velocity commands."/>
+  <arg name="angular_vel_scale" default="false" description="Apply scale factor for angular velocity commands."/>
 
-  <arg name="log_level_segway" default="info" description="Log level for segway_rmp_ros2"/>
+  <arg name="log_level_segway" default="info" description="Log level for segway_rmp_ros2."/>
+
+  <arg name="inter_cycle_delay" default="2.0" description="Idle gap between query cycles (seconds) for kokam battery service."/>
 
   <!-- Launch the laser filters -->
   <group if="$(var use_laser_filters)">
@@ -431,6 +433,7 @@
         <param name="charged_thr" value="29.39"/>
         <param name="medium_thr" value="25.5"/>
         <param name="low_thr" value="24.5"/>
+        <param name="inter_cycle_delay" value="2.0"/>
     </node>
   </group>
 </launch>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -99,7 +99,7 @@
 
   <arg name="log_level_segway" default="info" description="Log level for segway_rmp_ros2."/>
 
-  <arg name="inter_cycle_delay" default="2.0" description="Idle gap between query cycles (seconds) for kokam battery service."/>
+  <arg name="inter_cycle_delay" default="0.0" description="Idle gap between query cycles (seconds) for kokam battery service."/>
 
   <!-- Launch the laser filters -->
   <group if="$(var use_laser_filters)">
@@ -433,7 +433,7 @@
         <param name="charged_thr" value="29.39"/>
         <param name="medium_thr" value="25.5"/>
         <param name="low_thr" value="24.5"/>
-        <param name="inter_cycle_delay" value="2.0"/>
+        <param name="inter_cycle_delay" value="$(var inter_cycle_delay)"/>
     </node>
   </group>
 </launch>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -68,7 +68,7 @@
   <arg name="velocity_smoother_feedback_type" default="OPEN_LOOP" description="Feedback type for the velocity smoother. Options: CLOSED_LOOP, OPEN_LOOP"/>
   <arg name="dock_pose_stl_model_path" default="$(find-pkg-share vizzy_navigation)/models/docking_pattern.stl" description="Path to the STL model for the dock pose estimation"/>
   <arg name="battery_state" default="0" description="Initial battery state. 0: Not charging, 1: Charging"/>
-  <arg name="use_battery_state_simulation" default="true" description="Whether to use the battery state simulation node."/>
+  <arg name="use_battery_state_simulation" default="false" description="Whether to use the battery state simulation node or the real battery state."/>
   <arg name="publish_dock_point_cloud" default="false" description="Whether to publish the dock point cloud for visualization."/>
   <arg name="docking_bt_selection" default="0" description="Short integer flag to indicate the BT to use for the docking procedure. If set to 0, the docking procedure with staging pose navigation is activated, if set to 1, the docking procedure without staging pose navigation is activated, if set to 2, the estimator-only docking procedure is activated."/>
   <arg name="force_centroid_guess" default="false" description="Whether to force the centroid guess in the docking procedure."/>
@@ -420,10 +420,17 @@
     </group>
   </group>
 
-  <!-- Launch the battery state simulator script -->
-  <group>
+  <group if="$(var use_battery_state_simulation)">
     <node pkg="vizzy_navigation" exec="battery_state_simulator_service.py" name="battery_charging_service" output="screen">
         <param name="initial_battery_state" value="$(var battery_state)"/>
+    </node>
+  </group>
+  <group unless="$(var use_battery_state_simulation)">
+    <node pkg="vizzy_navigation" exec="battery_kokam_service.py" name="battery_kokam_service" output="screen">
+        <param name="port" value="/dev/kokam_power"/>
+        <param name="charged_thr" value="29.39"/>
+        <param name="medium_thr" value="25.5"/>
+        <param name="low_thr" value="24.5"/>
     </node>
   </group>
 </launch>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -53,7 +53,7 @@
   <arg name="cost_scaling_factor" default="3.0" description="Cost scaling factor for the inflation layer in the costmap"/>
   <arg name="base_obstacle_scale" default="0.02" description="Base obstacle scale for the costmap. This is used by the local and global costmaps to scale the cost of obstacles."/>
   <arg name="controller_plugin_type" default="MPPI" description="Type of controller plugin to use. Options: DWB, RPP, MPPI"/>
-  <arg name="expected_planner_frequency" default="0.1" description="Expected frequency of the planner in Hz"/>
+  <arg name="expected_planner_frequency" default="1.0" description="Expected frequency of the planner in Hz"/>
   <arg name="planner_plugin_type" default="ThetaStar" description="Planner plugin to use for the navigation stack"/>
   <arg name="robot_radius" default="0.4" description="Robot radius for the navigation stack. This is used by the local and global costmaps to scale the cost of obstacles."/>
   <arg name="mppi_wide_cost_critic_cost_weight" default="3.82" description="Cost weight for the wide MPPI cost critic"/>
@@ -75,11 +75,11 @@
   <arg name="use_statistical_outlier_removal_and_downsampling" default="true" description="Whether to use statistical outlier removal and downsampling in the dock pose estimator."/>
 
   <!-- General MPPI Controller Parameters -->
-  <arg name="mppi_cost_critic_cost_weight" default="3.82" description="Cost weight for the general MPPI cost critic"/>
-  <arg name="mppi_path_align_critic_cost_weight" default="14.0" description="Cost weight for the general MPPI path align critic"/>
+  <arg name="mppi_cost_critic_cost_weight" default="1.5" description="Cost weight for the general MPPI cost critic"/>
+  <arg name="mppi_path_align_critic_cost_weight" default="20.0" description="Cost weight for the general MPPI path align critic"/>
   <arg name="mppi_time_steps" default="64" description="Number of time steps (points) in candidate trajectories."/>
   <arg name="mppi_batch_size" default="2000" description="Count of randomly sampled candidate trajectories from current optimal control sequence in a given iteration."/>
-  <arg name="mppi_vx_std" default="0.1" description="Standard deviation for linear velocity in the MPPI controller."/>
+  <arg name="mppi_vx_std" default="0.3" description="Standard deviation for linear velocity in the MPPI controller."/>
   <arg name="mppi_wz_std" default="0.2" description="Standard deviation for the general MPPI controller"/>
   <arg name="mppi_vx_max" default="1.0" description="Maximum linear velocity in the MPPI controller."/>
   <arg name="mppi_temperature" default="0.3" description="Selectiveness of trajectories by their costs."/>

--- a/vizzy_launch/launch/vizzy_real_launch.xml
+++ b/vizzy_launch/launch/vizzy_real_launch.xml
@@ -89,7 +89,10 @@
   <arg name="staging_pose" default="-x -1.0 -y 0.0 -Y 0.0" description="Staging pose of the robot in the map frame for docking. Format: 'x y Yaw'"/>
   <arg name="always_send_full_costmap" default="false" description="Whether to always send the full costmap to the controller."/>
   <arg name="transform_tolerance" default="0.1" description="Transform tolerance for the navigation stack."/>
-  
+
+  <arg name="use_patrol" default="false" description="Launch the autonomous patrol node."/>
+  <arg name="patrol_waypoints_file" default="$(find-pkg-share vizzy_navigation)/config/patrol_waypoints_real.yaml" description="Path to the patrol waypoints YAML file."/>
+
   <!-- Both lasers have the same angle_min and angle_max specifications. -->
   <arg name="angle_min" default="-1.309" description="Minimum angle for the laser scanner."/>
   <arg name="angle_max" default="1.309" description="Maximum angle for the laser scanner."/>
@@ -195,6 +198,8 @@
           <arg name="staging_pose" value="$(var staging_pose)"/>
           <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
           <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
+          <arg name="use_patrol" value="$(var use_patrol)"/>
+          <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
         </include>
       </group>
       <group unless="$(var use_obstacles)">
@@ -261,6 +266,8 @@
           <arg name="staging_pose" value="$(var staging_pose)"/>
           <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
           <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
+          <arg name="use_patrol" value="$(var use_patrol)"/>
+          <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
         </include>
       </group>
     </group>
@@ -351,6 +358,8 @@
           <arg name="staging_pose" value="$(var staging_pose)"/>
           <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
           <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
+          <arg name="use_patrol" value="$(var use_patrol)"/>
+          <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
         </include>
       </group>
       <group unless="$(var use_obstacles)">
@@ -417,6 +426,8 @@
           <arg name="staging_pose" value="$(var staging_pose)"/>
           <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
           <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
+          <arg name="use_patrol" value="$(var use_patrol)"/>
+          <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
         </include>
       </group>
     </group>

--- a/vizzy_launch/launch/vizzy_simulation_launch.xml
+++ b/vizzy_launch/launch/vizzy_simulation_launch.xml
@@ -29,7 +29,7 @@
   <arg name="scan_topic_front" default="/nav_hokuyo_laser/front/scan" description="The name of the output scan topic"/> 
   <arg name="scan_topic_rear" default="/nav_hokuyo_laser/rear/scan" description="The name of the rear output scan topic"/>
   <arg name="params_file" default="$(find-pkg-share vizzy_navigation)/config/nav2_configuration.yaml" description="Path to the Nav2 parameters file"/> 
-  <arg name="controller_frequency" default="20.0" description="Frequency of the controller in Hz"/> 
+  <arg name="controller_frequency" default="20.0" description="Frequency of the controller in Hz"/>
   <arg name="path_align_forward_point_distance" default="0.325" description="Forward point distance for PathAlign"/>
   <arg name="goal_align_forward_point_distance" default="0.325" description="Forward point distance for GoalAlign"/>
   <arg name="inflation_radius" default="0.50" description="Inflation radius for the costmap"/>
@@ -76,6 +76,9 @@
   <arg name="staging_pose" default="-x -1.0 -y 0.0 -Y 0.0" description="Staging pose of the robot in the map frame for docking. Format: 'x y Yaw'"/>
   <arg name="always_send_full_costmap" default="false" description="Whether to always send the full costmap to the controller."/>
   <arg name="transform_tolerance" default="0.1" description="Transform tolerance for the navigation stack."/>
+
+  <arg name="use_patrol" default="false" description="Launch the autonomous patrol node."/>
+  <arg name="patrol_waypoints_file" default="$(find-pkg-share vizzy_navigation)/config/patrol_waypoints_simulation.yaml" description="Path to the patrol waypoints YAML file."/>
 
   <!-- Launch gazebo -->
   <include file="$(find-pkg-share vizzy_gazebo)/launch/gazebo_launch.xml">
@@ -150,6 +153,8 @@
       <arg name="staging_pose" value="$(var staging_pose)"/>
       <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
       <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
+      <arg name="use_patrol" value="$(var use_patrol)"/>
+      <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
     </include>
   </group>
   <group unless="$(var use_obstacles)">
@@ -209,6 +214,8 @@
       <arg name="staging_pose" value="$(var staging_pose)"/>
       <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
       <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
+      <arg name="use_patrol" value="$(var use_patrol)"/>
+      <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
     </include>
   </group>
 

--- a/vizzy_launch/launch/vizzy_simulation_launch.xml
+++ b/vizzy_launch/launch/vizzy_simulation_launch.xml
@@ -54,7 +54,7 @@
   <arg name="mppi_narrow_wz_std" default="0.13" description="Standard deviation for the narrow MPPI controller"/>
   <arg name="velocity_smoother_feedback_type" default="OPEN_LOOP" description="Feedback type for the velocity smoother. Options: CLOSED_LOOP, OPEN_LOOP"/>
   <arg name="dock_pose_stl_model_path" default="$(find-pkg-share vizzy_navigation)/models/docking_pattern.stl" description="Path to the STL model for the dock pose estimation"/>
-  <arg name="battery_state" default="0" description="Initial battery state. 0: Not charging, 1: Charging"/>
+  <arg name="battery_state" default="1" description="Initial battery state passed to the simulator. 0=CHARGED, 1=GOOD, 2=UNKNOWN, 3=LOW_BATTERY"/>
   <arg name="use_battery_state_simulation" default="true" description="Whether to use the battery state simulation node."/>
   <arg name="publish_dock_point_cloud" default="false" description="Whether to publish the dock point cloud for visualization."/>
   <arg name="docking_bt_selection" default="0" description="Short integer flag to indicate the BT to use for the docking procedure. If set to 0, the docking procedure with staging pose navigation is activated, if set to 1, the docking procedure without staging pose navigation is activated, if set to 2, the estimator-only docking procedure is activated."/>

--- a/vizzy_launch/launch/vizzy_simulation_launch.xml
+++ b/vizzy_launch/launch/vizzy_simulation_launch.xml
@@ -60,6 +60,8 @@
   <arg name="docking_bt_selection" default="0" description="Short integer flag to indicate the BT to use for the docking procedure. If set to 0, the docking procedure with staging pose navigation is activated, if set to 1, the docking procedure without staging pose navigation is activated, if set to 2, the estimator-only docking procedure is activated."/>
   <arg name="force_centroid_guess" default="false" description="Whether to force the centroid guess in the docking procedure."/>
   <arg name="use_statistical_outlier_removal_and_downsampling" default="true" description="Whether to use statistical outlier removal and downsampling in the dock pose estimator."/>
+  <arg name="staging_pose_simulation" default="-x -1.0 -y 0.0 -Y 0.0" description="Simulated dock pose in the format 'x y Yaw' for testing the docking procedure in simulation."/>
+  <arg name="staging_pose_real" default="-x -1.0 -y 0.0 -Y 0.0" description="Real dock pose in the format 'x y Yaw' for the docking procedure with the real robot."/>
 
   <!-- General MPPI Controller Parameters -->
   <arg name="mppi_cost_critic_cost_weight" default="10.0" description="Cost weight for the general MPPI cost critic"/>
@@ -73,7 +75,6 @@
   <arg name="mppi_iteration_count" default="1" description="Iteration count in the MPPI algorithm. Recommended to remain as 1 and instead prefer larger batch sizes."/>
   <arg name="mppi_constraint_critic_cost_weight" default="4.0" description="Cost weight for the MPPI constraint critic."/>
   
-  <arg name="staging_pose" default="-x -1.0 -y 0.0 -Y 0.0" description="Staging pose of the robot in the map frame for docking. Format: 'x y Yaw'"/>
   <arg name="always_send_full_costmap" default="false" description="Whether to always send the full costmap to the controller."/>
   <arg name="transform_tolerance" default="0.1" description="Transform tolerance for the navigation stack."/>
 
@@ -150,11 +151,12 @@
       <arg name="mppi_temperature" value="$(var mppi_temperature)"/>
       <arg name="mppi_iteration_count" value="$(var mppi_iteration_count)"/>
       <arg name="mppi_constraint_critic_cost_weight" value="$(var mppi_constraint_critic_cost_weight)"/>
-      <arg name="staging_pose" value="$(var staging_pose)"/>
       <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
       <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
       <arg name="use_patrol" value="$(var use_patrol)"/>
       <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
+      <arg name="staging_pose_simulation" value="$(var staging_pose_simulation)"/>
+      <arg name="staging_pose_real" value="$(var staging_pose_real)"/>
     </include>
   </group>
   <group unless="$(var use_obstacles)">
@@ -211,11 +213,12 @@
       <arg name="mppi_temperature" value="$(var mppi_temperature)"/>
       <arg name="mppi_iteration_count" value="$(var mppi_iteration_count)"/>
       <arg name="mppi_constraint_critic_cost_weight" value="$(var mppi_constraint_critic_cost_weight)"/>
-      <arg name="staging_pose" value="$(var staging_pose)"/>
       <arg name="always_send_full_costmap" value="$(var always_send_full_costmap)"/>
       <arg name="transform_tolerance" value="$(var transform_tolerance)"/>
       <arg name="use_patrol" value="$(var use_patrol)"/>
       <arg name="waypoints_file" value="$(var patrol_waypoints_file)"/>
+      <arg name="staging_pose_simulation" value="$(var staging_pose_simulation)"/>
+      <arg name="staging_pose_real" value="$(var staging_pose_real)"/>
     </include>
   </group>
 

--- a/vizzy_navigation/CMakeLists.txt
+++ b/vizzy_navigation/CMakeLists.txt
@@ -204,6 +204,7 @@ install(
 
 install(PROGRAMS
   script/battery_state_simulator_service.py
+  script/battery_kokam_service.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/vizzy_navigation/CMakeLists.txt
+++ b/vizzy_navigation/CMakeLists.txt
@@ -205,6 +205,7 @@ install(
 install(PROGRAMS
   script/battery_state_simulator_service.py
   script/battery_kokam_service.py
+  script/patrol_node.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/vizzy_navigation/CMakeLists.txt
+++ b/vizzy_navigation/CMakeLists.txt
@@ -24,7 +24,6 @@ find_package(tf2_ros REQUIRED)
 find_package(ndt_omp REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(teaserpp REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(pluginlib REQUIRED) 
 find_package(nav2_amcl REQUIRED)
@@ -98,7 +97,6 @@ ament_target_dependencies(docking_lib PUBLIC
   laser_geometry
   sensor_msgs
   geometry_msgs
-  teaserpp
   OpenMP
   ndt_omp
 )
@@ -109,9 +107,7 @@ target_link_libraries(docking_lib PUBLIC
   ${PCL_LIBRARIES}
   ${VTK_LIBRARIES}
 
-  Eigen3::Eigen 
-  teaserpp::teaser_registration 
-  teaserpp::teaser_io
+  Eigen3::Eigen
 )
 
 # Create the executable from ONLY the main() file.

--- a/vizzy_navigation/config/custom_navigate_to_pose_bt_navigator_nav2.xml
+++ b/vizzy_navigation/config/custom_navigate_to_pose_bt_navigator_nav2.xml
@@ -20,13 +20,15 @@
           <RecoveryNode number_of_retries="1" name="ComputePathToPose">
             <Sequence name="ComputeAndSmoothPath">
               <ComputePathToPose goal="{goal}" path="{path}" planner_id="PLANNER_PLACEHOLDER"/>
-              <SmoothPath unsmoothed_path="{path}" smoothed_path="{path}"/>
+              <ForceSuccess>
+                <SmoothPath unsmoothed_path="{path}" smoothed_path="{path}" smoother_id="SmoothPath"/>
+              </ForceSuccess>
             </Sequence>
             <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
           </RecoveryNode>
         </RateController>
         <RecoveryNode number_of_retries="1" name="FollowPath">
-          <FollowPath path="{path}" controller_id="CONTROLLER_PLACEHOLDER"/>
+          <FollowPath path="{path}" controller_id="CONTROLLER_PLACEHOLDER" goal_checker_id="general_goal_checker" progress_checker_id="progress_checker"/>
           <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
         </RecoveryNode>
       </PipelineSequence>

--- a/vizzy_navigation/config/nav2_configuration.yaml
+++ b/vizzy_navigation/config/nav2_configuration.yaml
@@ -398,7 +398,7 @@ controller_server:
         cost_weight: 3.0
         threshold_to_consider: 0.5
       PreferForwardCritic:
-        enabled: false
+        enabled: true
         cost_power: 1
         cost_weight: 5.0
         threshold_to_consider: 0.5

--- a/vizzy_navigation/config/nav2_configuration.yaml
+++ b/vizzy_navigation/config/nav2_configuration.yaml
@@ -93,7 +93,7 @@ controller_server:
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.25
+      xy_goal_tolerance: 0.35
       yaw_goal_tolerance: 0.1
 
     # DWB Parameters.
@@ -122,7 +122,7 @@ controller_server:
       linear_granularity: 0.05
       angular_granularity: 0.025
       transform_tolerance: 0.5 # Configurable
-      xy_goal_tolerance: 0.25
+      xy_goal_tolerance: 0.35
       trans_stopped_velocity: 0.25
       short_circuit_trajectory_evaluation: True
       stateful: True

--- a/vizzy_navigation/config/nav2_configuration.yaml
+++ b/vizzy_navigation/config/nav2_configuration.yaml
@@ -398,7 +398,7 @@ controller_server:
         cost_weight: 3.0
         threshold_to_consider: 0.5
       PreferForwardCritic:
-        enabled: true
+        enabled: false
         cost_power: 1
         cost_weight: 5.0
         threshold_to_consider: 0.5

--- a/vizzy_navigation/config/nav2_configuration.yaml
+++ b/vizzy_navigation/config/nav2_configuration.yaml
@@ -20,9 +20,9 @@ amcl:
     recovery_alpha_slow: 0.005
     resample_interval: 1
     sigma_hit: 0.2
-    transform_tolerance: 0.7 # Configurable
-    update_min_a: 0.05 # Configurable
-    update_min_d: 0.05 # Configurable
+    transform_tolerance: 0.3
+    update_min_a: 0.2 # Configurable
+    update_min_d: 0.2 # Configurable
     z_hit: 0.95
     z_max: 0.05
     z_rand: 0.05
@@ -500,7 +500,7 @@ global_costmap:
       lethal_cost_threshold: 100
       resolution: 0.05
       track_unknown_space: true
-      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      plugins: ["static_layer", "inflation_layer"]
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
@@ -589,8 +589,8 @@ smoother_server:
 
     SmoothPath:
       plugin: "nav2_constrained_smoother/ConstrainedSmoother"
-      reversing_enabled: true       
-      path_downsampling_factor: 3   
+      reversing_enabled: false       
+      path_downsampling_factor: 1   
       path_upsampling_factor: 1     
       keep_start_orientation: true 
       keep_goal_orientation: true   

--- a/vizzy_navigation/config/nav2_configuration.yaml
+++ b/vizzy_navigation/config/nav2_configuration.yaml
@@ -49,7 +49,7 @@ bt_navigator:
     robot_base_frame: base_footprint # Configurable
     odom_topic: /odom # Configurable
     bt_loop_duration: 50
-    default_server_timeout: 20
+    default_server_timeout: 10000
     wait_for_service_timeout: 1000
     plugin_lib_names:
       - nav2_lifecycle_manager_bt_node
@@ -492,7 +492,7 @@ global_costmap:
   global_costmap:
     ros__parameters:
       update_frequency: 5.0
-      publish_frequency: 1.0
+      publish_frequency: 5.0
       global_frame: map # Configurable
       robot_base_frame: base_footprint # Configurable
       use_sim_time: True # Configurable
@@ -584,6 +584,8 @@ smoother_server:
   ros__parameters:
     use_sim_time: True
     smoother_plugins: ["SmoothPath"]
+    costmap_topic: global_costmap/costmap_raw
+    footprint_topic: global_costmap/published_footprint
 
     SmoothPath:
       plugin: "nav2_constrained_smoother/ConstrainedSmoother"

--- a/vizzy_navigation/config/nav2_configuration.yaml
+++ b/vizzy_navigation/config/nav2_configuration.yaml
@@ -21,8 +21,8 @@ amcl:
     resample_interval: 1
     sigma_hit: 0.2
     transform_tolerance: 0.3
-    update_min_a: 0.2 # Configurable
-    update_min_d: 0.2 # Configurable
+    update_min_a: 0.01 # Configurable
+    update_min_d: 0.01 # Configurable
     z_hit: 0.95
     z_max: 0.05
     z_rand: 0.05

--- a/vizzy_navigation/config/patrol_waypoints_real.yaml
+++ b/vizzy_navigation/config/patrol_waypoints_real.yaml
@@ -1,0 +1,9 @@
+# Patrol waypoints for the autonomous patrol mission on the real 7th-floor map.
+# All poses are in the "map" frame.
+# Orientation is a quaternion (x, y, z, w).
+# TODO: Replace placeholder entries with validated real-robot waypoints.
+
+waypoints:
+  - frame_id: map
+    position:    {x: 0.0, y: 0.0, z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}

--- a/vizzy_navigation/config/patrol_waypoints_real.yaml
+++ b/vizzy_navigation/config/patrol_waypoints_real.yaml
@@ -1,9 +1,17 @@
 # Patrol waypoints for the autonomous patrol mission on the real 7th-floor map.
 # All poses are in the "map" frame.
 # Orientation is a quaternion (x, y, z, w).
-# TODO: Replace placeholder entries with validated real-robot waypoints.
 
 waypoints:
   - frame_id: map
-    position:    {x: 0.0, y: 0.0, z: 0.0}
-    orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}
+    position:    {x:  0.43108701705932617, y:  -2.950040817260742,  z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z: -0.7418734552970585, w:  0.6705399140436036}
+  - frame_id: map
+    position:    {x: -1.1347460746765137,  y: -16.821735382080078,  z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z: -0.07411726248797472, w: 0.9972495331667439}
+  - frame_id: map
+    position:    {x: 12.919004440307617,   y: -18.510698318481445,  z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z:  0.6505778360206717, w:  0.7594395823754909}
+  - frame_id: map
+    position:    {x: 14.512432098388672,   y:  -4.809907913208008,  z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z:  0.9950555298238773, w:  0.09932015186719509}

--- a/vizzy_navigation/config/patrol_waypoints_simulation.yaml
+++ b/vizzy_navigation/config/patrol_waypoints_simulation.yaml
@@ -1,0 +1,22 @@
+# Patrol waypoints for the autonomous patrol mission in the simulation environment.
+# All poses are in the "map" frame.
+# Orientation is a quaternion (x, y, z, w). For a robot facing along +X: w=1.0, rest 0.
+# The robot visits waypoints in order and restarts from waypoint 0 after each loop
+# or after returning from a charging dock.
+
+waypoints:
+  - frame_id: map
+    position:    {x: -2.477031707763672,     y: 3.4208154678344727,  z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z: 0.6564072984776258,   w: 0.754406693041164}
+
+  - frame_id: map
+    position:    {x: -2.6785964965820312,    y: 17.260581970214844,  z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z: -0.9999479250975207,  w: 0.010205248314617553}
+
+  - frame_id: map
+    position:    {x: -16.07689094543457,     y: 16.554548263549805,  z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z: -0.7016183530013241,  w: 0.7125529360908629}
+
+  - frame_id: map
+    position:    {x: -15.626153945922852,    y: 3.431760787963867,   z: 0.0}
+    orientation: {x: 0.0, y: 0.0, z: -0.0009856676380607817, w: 0.9999995142295357}

--- a/vizzy_navigation/include/dock_pose_estimator.h
+++ b/vizzy_navigation/include/dock_pose_estimator.h
@@ -34,7 +34,6 @@
 #include <pcl/search/kdtree.h>
 #include <pcl/common/common.h>
 #include <pcl/PCLPointCloud2.h>
-#include "teaser/registration.h"
 #include <pcl/registration/icp.h>
 #include <pcl/registration/ndt.h>   
 #include <tf2_eigen/tf2_eigen.hpp>

--- a/vizzy_navigation/launch/navigation_launch.py
+++ b/vizzy_navigation/launch/navigation_launch.py
@@ -651,11 +651,6 @@ def generate_launch_description():
         description='Full path to the patrol waypoints YAML file.'
     )
 
-    staging_pose_arg = DeclareLaunchArgument(
-        'staging_pose',
-        default_value='-x 0.0 -y 0.0 -Y 0.0',
-        description='Staging pose of the robot in the map frame for docking.'
-    )
     always_send_full_costmap_arg = DeclareLaunchArgument(
         'always_send_full_costmap',
         default_value='false',
@@ -665,6 +660,16 @@ def generate_launch_description():
         'transform_tolerance',
         default_value='0.1',
         description='Transform tolerance for the navigation stack.'
+    )
+    staging_pose_simulation_arg = DeclareLaunchArgument(
+        'staging_pose_simulation',
+        default_value='-x -1.0 -y 0.0 -Y 0.0',
+        description='Simulated dock pose in the format \'x y Yaw\' for testing the docking procedure in simulation.'
+    )
+    staging_pose_real_arg = DeclareLaunchArgument(
+        'staging_pose_real',
+        default_value='-x -1.0 -y 0.0 -Y 0.0',
+        description='Real dock pose in the format \'x y Yaw\' for the docking procedure with the real robot.'
     )
 
     # --- Launch Configurations ---
@@ -678,9 +683,10 @@ def generate_launch_description():
     laser_rear_topic = LaunchConfiguration('scan_topic_rear')
     publish_dock_point_cloud = LaunchConfiguration('publish_dock_point_cloud')
     docking_bt_selection = LaunchConfiguration('docking_bt_selection') 
-    staging_pose_str = LaunchConfiguration('staging_pose')
     force_centroid_guess = LaunchConfiguration('force_centroid_guess')
     use_statistical_outlier_removal_and_downsampling = LaunchConfiguration('use_statistical_outlier_removal_and_downsampling')
+    staging_pose_simulation = LaunchConfiguration('staging_pose_simulation')
+    staging_pose_real = LaunchConfiguration('staging_pose_real')
 
     package_name = 'vizzy_navigation' 
 
@@ -894,7 +900,8 @@ def generate_launch_description():
                 output='screen',
                 parameters=[{'is_simulation': use_battery_state_simulation},
                             {'docking_bt_selection': docking_bt_selection},
-                            {'staging_pose': staging_pose_str},
+                            {'staging_pose_simulation': staging_pose_simulation},
+                            {'staging_pose_real': staging_pose_real},
                             ],),
                 # Uncomment the next line to debug the node with GDB.
                 # prefix=['xterm -e gdb -ex run --args']),
@@ -987,7 +994,8 @@ def generate_launch_description():
         mppi_cost_critic_cost_weight_arg,
         mppi_path_align_critic_cost_weight_arg,
         mppi_wz_std_arg,
-        staging_pose_arg,
+        staging_pose_simulation_arg,
+        staging_pose_real_arg,
         always_send_full_costmap_arg,
         transform_tolerance_arg,
         use_patrol_arg,

--- a/vizzy_navigation/launch/navigation_launch.py
+++ b/vizzy_navigation/launch/navigation_launch.py
@@ -31,6 +31,7 @@ import yaml
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction, LogInfo, OpaqueFunction
+from launch.conditions import IfCondition
 from launch.launch_context import LaunchContext
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node, PushRosNamespace, LifecycleNode
@@ -639,6 +640,17 @@ def generate_launch_description():
 
     # -------------------------------------------
     
+    use_patrol_arg = DeclareLaunchArgument(
+        'use_patrol',
+        default_value='false',
+        description='Launch the autonomous patrol node alongside the navigation stack.'
+    )
+    waypoints_file_arg = DeclareLaunchArgument(
+        'waypoints_file',
+        default_value=os.path.join(pkg_dir, 'config', 'patrol_waypoints_simulation.yaml'),
+        description='Full path to the patrol waypoints YAML file.'
+    )
+
     staging_pose_arg = DeclareLaunchArgument(
         'staging_pose',
         default_value='-x 0.0 -y 0.0 -Y 0.0',
@@ -880,12 +892,26 @@ def generate_launch_description():
                 executable='charging_action_server_node',
                 name='charging_action_server_node',
                 output='screen',
-                parameters=[{'is_simulation': use_battery_state_simulation}, 
+                parameters=[{'is_simulation': use_battery_state_simulation},
                             {'docking_bt_selection': docking_bt_selection},
                             {'staging_pose': staging_pose_str},
                             ],),
                 # Uncomment the next line to debug the node with GDB.
                 # prefix=['xterm -e gdb -ex run --args']),
+
+            # Only launch the patrol node if the use_patrol launch argument is set to true. 
+            # This allows us to keep the patrol node separate from the main navigation stack.
+            Node(
+                condition=IfCondition(LaunchConfiguration('use_patrol')),
+                package='vizzy_navigation',
+                executable='patrol_node.py',
+                name='patrol_node',
+                output='screen',
+                parameters=[{
+                    'waypoints_file': LaunchConfiguration('waypoints_file'),
+                    'is_simulation': use_battery_state_simulation,
+                    'battery_check_period_s': 5.0,
+                }],),
 
             # A separate Lifecycle manager for the dock_pose_estimator_node
             # to be able to launch the node without starting it.
@@ -964,6 +990,8 @@ def generate_launch_description():
         staging_pose_arg,
         always_send_full_costmap_arg,
         transform_tolerance_arg,
+        use_patrol_arg,
+        waypoints_file_arg,
         mppi_batch_size_arg,
         mppi_time_steps_arg,
         mppi_vx_std_arg,

--- a/vizzy_navigation/launch/navigation_launch.py
+++ b/vizzy_navigation/launch/navigation_launch.py
@@ -182,7 +182,7 @@ def save_rewritten_yaml(context: LaunchContext, output_file_path: str = None, ou
         'amcl.ros__parameters.beam_skip_error_threshold': float(LaunchConfiguration('beam_skip_error_threshold').perform(context)),
         'amcl.ros__parameters.beam_skip_threshold': float(LaunchConfiguration('beam_skip_threshold').perform(context)),
         'amcl.ros__parameters.do_beamskip': LaunchConfiguration('do_beamskip').perform(context),
-        'amcl.ros__parameters.transform_tolerance': float(LaunchConfiguration('transform_tolerance').perform(context)),
+        # 'amcl.ros__parameters.transform_tolerance': float(LaunchConfiguration('transform_tolerance').perform(context)),
 
         # BT Navigator substitutions.
         'bt_navigator.ros__parameters.global_frame': LaunchConfiguration('map_frame_id').perform(context),

--- a/vizzy_navigation/launch/navigation_launch.py
+++ b/vizzy_navigation/launch/navigation_launch.py
@@ -491,7 +491,7 @@ def generate_launch_description():
     )
     expected_planner_frequency_arg = DeclareLaunchArgument(
         'expected_planner_frequency',
-        default_value='0.1',
+        default_value='1.0',
         description='Expected frequency of the planner in Hz.'
     )
     planner_plugin_arg = DeclareLaunchArgument(
@@ -589,12 +589,12 @@ def generate_launch_description():
 
     mppi_cost_critic_cost_weight_arg = DeclareLaunchArgument(
         'mppi_cost_critic_cost_weight',
-        default_value='3.82',
+        default_value='1.5',
         description='Cost weight for the general MPPI cost critic.'
     )
     mppi_path_align_critic_cost_weight_arg = DeclareLaunchArgument(
         'mppi_path_align_critic_cost_weight',
-        default_value='14.0',
+        default_value='20.0',
         description='Cost weight for the general MPPI path align critic.'
     )
     mppi_time_steps_arg = DeclareLaunchArgument(

--- a/vizzy_navigation/package.xml
+++ b/vizzy_navigation/package.xml
@@ -35,7 +35,7 @@
   <build_depend>tf2</build_depend> 
 
   <!-- Execution dependencies -->
-  <exec_depend>tf2</exec_depend> 
+  <exec_depend>tf2</exec_depend>
   <exec_depend>rviz2</exec_depend> 
   <exec_depend>tf2_msgs</exec_depend> 
   <exec_depend>std_msgs</exec_depend> 
@@ -44,12 +44,13 @@
   <exec_depend>nav2_common</exec_depend> 
   <exec_depend>nav2_planner</exec_depend> 
   <exec_depend>nav2_smoother</exec_depend> 
+  <exec_depend>python3-serial</exec_depend>
   <exec_depend>nav2_behaviors</exec_depend> 
   <exec_depend>nav2_controller</exec_depend> 
   <exec_depend>nav2_map_server</exec_depend> 
   <exec_depend>nav2_bt_navigator</exec_depend> 
-  <exec_depend>nav2_navfn_planner</exec_depend> 
   <exec_depend>nav2_smac_planner</exec_depend>
+  <exec_depend>nav2_navfn_planner</exec_depend> 
   <exec_depend>nav2_dwb_controller</exec_depend> 
   <exec_depend>nav2_mppi_controller</exec_depend>
   <exec_depend>nav2_waypoint_follower</exec_depend> 

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -161,8 +161,13 @@ class BatteryKokamService(Node):
         self._current_charging_state: int = BatteryChargingState.Response.NOT_CHARGING
 
         # Serial port setup.
+        # dsrdtr=False / rtscts=False prevents pyserial from asserting DTR/RTS
+        # on open. Trying to fix infinite reset loop.
         try:
-            self._serial = serial.Serial(port, baudrate=115200, timeout=1)
+            self._serial = serial.Serial(
+                port, baudrate=115200, timeout=1, dsrdtr=False, rtscts=False
+            )
+            self._serial.dtr = False
             self.get_logger().info(f'{port} open at 115200 baud')
         except serial.SerialException as exc:
             self.get_logger().fatal(f'Cannot open serial port {port}: {exc}')

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -72,13 +72,14 @@
 #     slope < −slope_threshold   →  transition to NOT_CHARGING
 #     slope ≥ −slope_threshold   →  remain CHARGING
 #
-# A real charging event is expected to produce a sustained positive slope well 
-# above the quantisation-noise floor, however the threshold should still be 
-# validated on the hardware (TODO). Quantisation noise, which has no dominant direction, 
-# never exceeds the threshold in a sustained way and cannot trigger
+# A real charging event is expected to produce a sustained positive slope well
+# above the quantisation-noise floor, however the threshold should still be
+# validated on the hardware (TODO). Quantisation noise, which has no dominant
+# direction, never exceeds the threshold in a sustained way and cannot trigger
 # a false transition. The service always returns a definite CHARGING or
-# NOT_CHARGING, thus the UNKNOWN state is reserved only for the startup period
-# before `min_slope_samples` have been collected.
+# NOT_CHARGING, including during the startup window and after a serial port
+# reopen, where the hysteresis state (initialised to NOT_CHARGING) is returned
+# instead.
 #
 # Serial port resilience
 # ----------------------
@@ -313,7 +314,7 @@ class BatteryKokamService(Node):
         R = BatteryChargingState.Response
 
         if len(samples) < self._min_slope_samples:
-            response.battery_charging_state = R.UNKNOWN
+            response.battery_charging_state = self._current_charging_state
             return response
 
         slope = self._l2_slope(samples)

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+
+# Copyright 2025, João Penha Lopes. All rights reserved.
+#
+# Migrated from ROS1 vizzy_serial_interfaces (battery-state-service.cpp and
+# battery-charging-state-service.cpp) by João Penha Lopes.
+#
+# Provides two real-hardware-backed services sourced from the Kokam battery
+# serial PCB.
+
+import collections
+import math
+import threading
+import time
+
+import rclpy
+import serial
+from rclpy.node import Node
+from vizzy_msgs.srv import BatteryChargingState, BatteryState
+
+
+class BatteryKokamService(Node):
+    """Reads voltage and current from the Kokam battery serial PCB and exposes
+    two ROS 2 services: battery_state and battery_charging_state.
+
+    A background thread polls the serial port continuously so that both service
+    handlers return immediately without blocking on I/O.
+    """
+
+    # Voltage range for percentage calculation, matches ROS1 hardcoded values.
+    _MIN_VOLTAGE = 22.0
+    _MAX_VOLTAGE = 29.4
+
+    def __init__(self):
+        super().__init__('battery_kokam_service')
+
+        # Parameters (defaults match ROS1 battery-state.launch).
+        self.declare_parameter('port', '/dev/kokam_power')
+        self.declare_parameter('charged_thr', 29.39)
+        self.declare_parameter('medium_thr', 25.5)
+        self.declare_parameter('low_thr', 24.5)
+
+        # Number of samples used for slope calculation and the minimum required
+        # before reporting a charging state, both set to 40 to match the ROS1
+        # battery-charging-state-service.cpp (samples = 40).
+        self.declare_parameter('slope_window', 40)
+        self.declare_parameter('min_slope_samples', 40)
+
+        port = self.get_parameter('port').value
+        self._charged_thr = self.get_parameter('charged_thr').value
+        self._medium_thr = self.get_parameter('medium_thr').value
+        self._low_thr = self.get_parameter('low_thr').value
+        slope_window = self.get_parameter('slope_window').value
+        self._min_slope_samples = self.get_parameter('min_slope_samples').value
+
+        # Thread-safe sample buffer.
+        self._lock = threading.Lock()
+        # maxlen matches slope_window so the deque acts as a rolling window.
+        self._samples: collections.deque = collections.deque(maxlen=slope_window)
+        self._latest_voltage: float | None = None
+
+        # Serial port setup.
+        try:
+            self._serial = serial.Serial(port, baudrate=115200, timeout=1)
+            self.get_logger().info(f'{port} open at 115200 baud')
+        except serial.SerialException as exc:
+            self.get_logger().fatal(f'Cannot open serial port {port}: {exc}')
+            raise
+
+        # Background reader.
+        reader = threading.Thread(target=self._read_loop, daemon=True)
+        reader.start()
+
+        # Services.
+        self.create_service(BatteryState, 'battery_state', self._handle_battery_state)
+        self.create_service(
+            BatteryChargingState, 'battery_charging_state', self._handle_battery_charging_state
+        )
+
+        self.get_logger().info('Battery Kokam service ready.')
+
+    # ------------------------------------------------------------------
+    # Serial reader (background thread)
+    # ------------------------------------------------------------------
+
+    def _read_loop(self) -> None:
+        """Continuously reads voltage and current from the Kokam PCB.
+
+        Protocol (mirrors VoltageCurrentSerialInterface::getSystemPowerSupply):
+          1. Write byte '0'
+          2. Sleep 300 ms
+          3. Read 8 bytes
+          4. Sleep 300 ms
+          5. Validate: buf[0] == '0', checksum(buf[0:6]) == buf[6:8] as uint16 BE
+          6. Decode: voltage = (buf[1]<<8 | buf[2]) / 100.0
+                     current = (buf[3]<<8 | buf[4]) / 100.0
+        """
+        while rclpy.ok():
+            try:
+                self._serial.write(b'0')
+                time.sleep(0.3)
+                buf = self._serial.read(8)
+                time.sleep(0.3)
+
+                if len(buf) != 8 or buf[0] != ord('0'):
+                    self.get_logger().warning(
+                        f'Unexpected response: {len(buf)} bytes, '
+                        f'first=0x{buf[0]:02x}' if buf else 'empty'
+                    )
+                    continue
+
+                byte_sum = sum(buf[:6])
+                checksum = (buf[6] << 8) | buf[7]
+                if checksum != byte_sum:
+                    self.get_logger().warning('Checksum mismatch, sample discarded.')
+                    continue
+
+                voltage = ((buf[1] << 8) | buf[2]) / 100.0
+                # current is decoded but unused for state logic (unsigned, matches ROS1).
+                # current = ((buf[3] << 8) | buf[4]) / 100.0
+
+                with self._lock:
+                    self._samples.append((time.monotonic(), voltage))
+                    self._latest_voltage = voltage
+
+            except serial.SerialException as exc:
+                self.get_logger().error(f'Serial read error: {exc}')
+                time.sleep(1.0)
+
+    # ------------------------------------------------------------------
+    # Service handlers
+    # ------------------------------------------------------------------
+
+    def _classify_voltage(self, voltage: float) -> int:
+        """Maps a voltage reading to a BatteryState constant.
+
+        Mirrors battery_state_logic() in battery-state-service.cpp exactly.
+        """
+        R = BatteryState.Response
+        if voltage > self._charged_thr:
+            return R.CHARGED
+        if voltage > self._medium_thr:
+            return R.GOOD
+        if voltage > self._low_thr:
+            return R.MEDIUM
+        return R.LOW_BATTERY
+
+    def _handle_battery_state(
+        self, request: BatteryState.Request, response: BatteryState.Response
+    ) -> BatteryState.Response:
+        with self._lock:
+            voltage = self._latest_voltage
+
+        if voltage is None:
+            response.battery_state = BatteryState.Response.UNKNOWN
+            response.percentage = 101  # sentinel used in ROS1 on read failure.
+        else:
+            response.battery_state = self._classify_voltage(voltage)
+            pct = 100.0 * (voltage - self._MIN_VOLTAGE) / (self._MAX_VOLTAGE - self._MIN_VOLTAGE)
+            response.percentage = int(math.floor(pct))
+
+        self.get_logger().info(
+            f'battery_state → state={response.battery_state} percentage={response.percentage}'
+        )
+        return response
+
+    @staticmethod
+    def _l2_slope(samples: list) -> float:
+        """Least-squares slope (V/s) of (time, voltage) pairs.
+
+        Mirrors l2_line_fitting() in battery-charging-state-service.cpp.
+        Returns 0.0 when the denominator is zero (all timestamps identical).
+        """
+        n = len(samples)
+        t_vals = [s[0] for s in samples]
+        v_vals = [s[1] for s in samples]
+        t_sum = sum(t_vals)
+        v_sum = sum(v_vals)
+        t2_sum = sum(t * t for t in t_vals)
+        tv_sum = sum(t * v for t, v in zip(t_vals, v_vals))
+        denom = n * t2_sum - t_sum * t_sum
+        if denom == 0.0:
+            return 0.0
+        return (n * tv_sum - t_sum * v_sum) / denom
+
+    def _handle_battery_charging_state(
+        self,
+        request: BatteryChargingState.Request,
+        response: BatteryChargingState.Response,
+    ) -> BatteryChargingState.Response:
+        with self._lock:
+            samples = list(self._samples)
+
+        R = BatteryChargingState.Response
+        if len(samples) < self._min_slope_samples:
+            response.battery_charging_state = R.UNKNOWN
+        else:
+            slope = self._l2_slope(samples)
+            self.get_logger().info(f'battery_charging_state → slope={slope:.6f} V/s')
+            response.battery_charging_state = R.CHARGING if slope > 0.0 else R.NOT_CHARGING
+
+        return response
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def destroy_node(self) -> None:
+        if self._serial.is_open:
+            self._serial.close()
+        super().destroy_node()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = BatteryKokamService()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -91,6 +91,7 @@
 
 import collections
 import math
+import termios
 import threading
 import time
 
@@ -225,7 +226,7 @@ class BatteryKokamService(Node):
                     self._samples.append((time.monotonic(), voltage))
                     self._latest_voltage = voltage
 
-            except serial.SerialException as exc:
+            except (serial.SerialException, termios.error) as exc:
                 self.get_logger().error(f'Serial read error: {exc}')
                 consecutive_errors += 1
                 time.sleep(1.0)

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -196,6 +196,7 @@ class BatteryKokamService(Node):
 
         while rclpy.ok():
             try:
+                self._serial.reset_input_buffer()
                 self._serial.write(b'0')
                 time.sleep(0.3)
                 buf = self._serial.read(8)

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -133,12 +133,10 @@ class BatteryKokamService(Node):
         # noise floor (~0.0004 V/s) observed on this hardware.
         self.declare_parameter('slope_threshold', 0.001)
 
-        # Idle gap between query cycles (seconds). Continuous 600ms polling 
-        # can stress the USB-serial bridge and trigger resets (TODO). ~
-        # Default 2s gives ~2.6 s per cycle while
-        # keeping the slope window to ~104 s (still well above noise floor).
-        # Set to 0.0 to match the tightest ROS1-equivalent polling rate.
-        self.declare_parameter('inter_cycle_delay', 2.0)
+        # Optional idle gap between query cycles (seconds). Set to 0.0 for
+        # the tightest ROS1-equivalent polling rate (~600 ms/sample, 40 samples
+        # fills the slope window in ~24 s).
+        self.declare_parameter('inter_cycle_delay', 0.0)
 
         port = self.get_parameter('port').value
         self._charged_thr = self.get_parameter('charged_thr').value

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-
-# Copyright 2025, João Penha Lopes. All rights reserved.
+#
+# Copyright 2026, João Penha Lopes. All rights reserved.
 #
 # Migrated from ROS1 vizzy_serial_interfaces (battery-state-service.cpp and
 # battery-charging-state-service.cpp) by João Penha Lopes.

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -249,8 +249,14 @@ class BatteryKokamService(Node):
                     )
                     try:
                         self._serial.close()
+                        # Wait for the USB-serial bridge to finish its
+                        # re-enumeration cycle before attempting reopen.
                         time.sleep(2.0)
                         self._serial.open()
+                        # Discard any garbage left in the FIFO from before
+                        # the reset, then wait for the line to settle.
+                        self._serial.reset_input_buffer()
+                        time.sleep(0.5)
                         with self._lock:
                             self._samples.clear()
                         consecutive_errors = 0

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -88,6 +88,14 @@
 # loop detects consecutive SerialException errors and attempts to reopen the
 # port after a short back-off, clearing the sample buffer so that stale
 # data spanning the error gap cannot distort the slope estimate.
+#
+# Notes: before figuring out that the issue of the constant USB-resetting was
+# due to the USB hub, I tried turning autosuspend off:
+# vizzy@vizzy-System-Product-Name:~$ cat /etc/udev/rules.d/99-kokam-battery.rules
+# SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="Vizzy_BAT", SYMLINK+="kokam_power", MODE="0666"
+# SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="Vizzy_BAT", ATTR{power/control}="on"
+# Shouldn't affect anything else though.
+
 
 import collections
 import math

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -133,6 +133,13 @@ class BatteryKokamService(Node):
         # noise floor (~0.0004 V/s) observed on this hardware.
         self.declare_parameter('slope_threshold', 0.001)
 
+        # Idle gap between query cycles (seconds). Continuous 600ms polling 
+        # can stress the USB-serial bridge and trigger resets (TODO). ~
+        # Default 2s gives ~2.6 s per cycle while
+        # keeping the slope window to ~104 s (still well above noise floor).
+        # Set to 0.0 to match the tightest ROS1-equivalent polling rate.
+        self.declare_parameter('inter_cycle_delay', 2.0)
+
         port = self.get_parameter('port').value
         self._charged_thr = self.get_parameter('charged_thr').value
         self._medium_thr = self.get_parameter('medium_thr').value
@@ -140,6 +147,7 @@ class BatteryKokamService(Node):
         slope_window = self.get_parameter('slope_window').value
         self._min_slope_samples = self.get_parameter('min_slope_samples').value
         self._slope_threshold = self.get_parameter('slope_threshold').value
+        self._inter_cycle_delay = self.get_parameter('inter_cycle_delay').value
 
         # Thread-safe sample buffer.
         self._lock = threading.Lock()
@@ -226,6 +234,9 @@ class BatteryKokamService(Node):
                     self._samples.append((time.monotonic(), voltage))
                     self._latest_voltage = voltage
 
+                if self._inter_cycle_delay > 0.0:
+                    time.sleep(self._inter_cycle_delay)
+
             except (serial.SerialException, termios.error) as exc:
                 self.get_logger().error(f'Serial read error: {exc}')
                 consecutive_errors += 1
@@ -246,7 +257,7 @@ class BatteryKokamService(Node):
                         self.get_logger().info(
                             f'{self._serial.port} reopened successfully.'
                         )
-                    except serial.SerialException as reopen_exc:
+                    except (serial.SerialException, OSError) as reopen_exc:
                         self.get_logger().error(f'Reopen failed: {reopen_exc}')
 
     # ------------------------------------------------------------------

--- a/vizzy_navigation/script/battery_kokam_service.py
+++ b/vizzy_navigation/script/battery_kokam_service.py
@@ -6,7 +6,87 @@
 # battery-charging-state-service.cpp) by João Penha Lopes.
 #
 # Provides two real-hardware-backed services sourced from the Kokam battery
-# serial PCB.
+# serial PCB: battery_state and battery_charging_state.
+#
+# ------------------------------------------------------------------------------
+# Design notes: differences from ROS1 and why this version is better
+# ------------------------------------------------------------------------------
+#
+# ROS1 architecture (battery-state-service.cpp,
+#                    battery-charging-state-service.cpp)
+# ------------------------------------------------------
+# Both services were blocking:
+#
+#   battery_state         — on each service call, performed one serial
+#                           round-trip (write '0', sleep 300 ms, read 8 bytes,
+#                           sleep 300 ms) and returned immediately. Latency
+#                           per call: ~600 ms.
+#
+#   battery_charging_state — on each service call, performed 40 sequential
+#                           round-trips (samples = 40), collecting
+#                           (timestamp, voltage) pairs, then fitted a linear
+#                           slope with L2 least squares. Total latency per
+#                           call: 40 × 600 ms ≈ 24 seconds. The ROS service
+#                           thread was blocked for the entire collection period.
+#                           Classification: slope > 0 → CHARGING,
+#                                           slope ≤ 0 → NOT_CHARGING.
+#
+# ROS2 architecture (this file)
+# -----------------------------
+# A single background thread polls the serial port continuously at the same
+# ~600 ms/sample rate and maintains a rolling deque of the last `slope_window`
+# (default 40) samples. Both service handlers read from this shared buffer and
+# return immediately. This eliminates the 24-second blocking call while
+# preserving the same sampling protocol and slope estimation as ROS1, 
+# while using a more robust charging-state decision rule for the continuously 
+# updated ROS2 architecture.
+#
+# Charging-state noise problem and hysteresis solution
+# ----------------------------------------------------
+# The voltage is decoded as a 16-bit unsigned integer divided by 100, giving
+# a resolution of 0.01 V per LSB. When the battery is static (no charger, no
+# load change), the true voltage is flat, but individual readings fluctuate by
+# ±1 LSB due to ADC quantisation noise. Over a 40-sample / 24-second window
+# this produces a spurious slope of approximately:
+#
+#   noise slope ≈ ΔV / Δt = 0.01 V / 24 s ≈ 0.0004 V/s
+#
+# In ROS1 this was not observable in practice because the 24-second collection
+# was triggered on demand (typically infrequently). In this ROS2 port the
+# rolling window is continuously updated, so consecutive service calls see
+# overlapping sample sets whose slope oscillates around zero at the noise
+# magnitude above, causing false CHARGING / NOT_CHARGING transitions on a
+# static, uncharged battery.
+#
+# The solution we decided to apply in this case is hysteresis: 
+# the threshold to enter a state differs from the threshold to
+# exit it, and in the absence of a clear signal the system holds its last
+# known state. This node implements symmetric hysteresis with a single
+# `slope_threshold` parameter (default 0.001 V/s, ~2.5× the noise floor):
+#
+#   current state = NOT_CHARGING:
+#     slope >  +slope_threshold  →  transition to CHARGING
+#     slope ≤  +slope_threshold  →  remain NOT_CHARGING
+#
+#   current state = CHARGING:
+#     slope < −slope_threshold   →  transition to NOT_CHARGING
+#     slope ≥ −slope_threshold   →  remain CHARGING
+#
+# A real charging event is expected to produce a sustained positive slope well 
+# above the quantisation-noise floor, however the threshold should still be 
+# validated on the hardware (TODO). Quantisation noise, which has no dominant direction, 
+# never exceeds the threshold in a sustained way and cannot trigger
+# a false transition. The service always returns a definite CHARGING or
+# NOT_CHARGING, thus the UNKNOWN state is reserved only for the startup period
+# before `min_slope_samples` have been collected.
+#
+# Serial port resilience
+# ----------------------
+# USB-to-serial devices can undergo kernel-level resets (autosuspend, power
+# glitch, udev re-trigger) that invalidate the open file descriptor. The read
+# loop detects consecutive SerialException errors and attempts to reopen the
+# port after a short back-off, clearing the sample buffer so that stale
+# data spanning the error gap cannot distort the slope estimate.
 
 import collections
 import math
@@ -46,18 +126,29 @@ class BatteryKokamService(Node):
         self.declare_parameter('slope_window', 40)
         self.declare_parameter('min_slope_samples', 40)
 
+        # Hysteresis dead-band: slope must exceed this magnitude (V/s) to
+        # trigger a state transition. Default is ~2.5× the ADC quantisation
+        # noise floor (~0.0004 V/s) observed on this hardware.
+        self.declare_parameter('slope_threshold', 0.001)
+
         port = self.get_parameter('port').value
         self._charged_thr = self.get_parameter('charged_thr').value
         self._medium_thr = self.get_parameter('medium_thr').value
         self._low_thr = self.get_parameter('low_thr').value
         slope_window = self.get_parameter('slope_window').value
         self._min_slope_samples = self.get_parameter('min_slope_samples').value
+        self._slope_threshold = self.get_parameter('slope_threshold').value
 
         # Thread-safe sample buffer.
         self._lock = threading.Lock()
         # maxlen matches slope_window so the deque acts as a rolling window.
         self._samples: collections.deque = collections.deque(maxlen=slope_window)
         self._latest_voltage: float | None = None
+
+        # Hysteresis state: persists between service calls.
+        # Initialised to NOT_CHARGING and matches initial_battery_state=0 used
+        # by the simulator which is correct when the charger is disconnected.
+        self._current_charging_state: int = BatteryChargingState.Response.NOT_CHARGING
 
         # Serial port setup.
         try:
@@ -94,13 +185,22 @@ class BatteryKokamService(Node):
           5. Validate: buf[0] == '0', checksum(buf[0:6]) == buf[6:8] as uint16 BE
           6. Decode: voltage = (buf[1]<<8 | buf[2]) / 100.0
                      current = (buf[3]<<8 | buf[4]) / 100.0
+
+        On persistent serial errors the port is closed and reopened. The sample
+        buffer is cleared on reopen so that the time gap does not corrupt the
+        slope estimate.
         """
+        consecutive_errors = 0
+        max_consecutive_errors = 3
+
         while rclpy.ok():
             try:
                 self._serial.write(b'0')
                 time.sleep(0.3)
                 buf = self._serial.read(8)
                 time.sleep(0.3)
+
+                consecutive_errors = 0  # reset on any successful I/O.
 
                 if len(buf) != 8 or buf[0] != ord('0'):
                     self.get_logger().warning(
@@ -125,7 +225,26 @@ class BatteryKokamService(Node):
 
             except serial.SerialException as exc:
                 self.get_logger().error(f'Serial read error: {exc}')
+                consecutive_errors += 1
                 time.sleep(1.0)
+
+                if consecutive_errors >= max_consecutive_errors:
+                    self.get_logger().warning(
+                        f'Attempting to reopen {self._serial.port} after '
+                        f'{consecutive_errors} consecutive errors...'
+                    )
+                    try:
+                        self._serial.close()
+                        time.sleep(2.0)
+                        self._serial.open()
+                        with self._lock:
+                            self._samples.clear()
+                        consecutive_errors = 0
+                        self.get_logger().info(
+                            f'{self._serial.port} reopened successfully.'
+                        )
+                    except serial.SerialException as reopen_exc:
+                        self.get_logger().error(f'Reopen failed: {reopen_exc}')
 
     # ------------------------------------------------------------------
     # Service handlers
@@ -192,13 +311,25 @@ class BatteryKokamService(Node):
             samples = list(self._samples)
 
         R = BatteryChargingState.Response
+
         if len(samples) < self._min_slope_samples:
             response.battery_charging_state = R.UNKNOWN
-        else:
-            slope = self._l2_slope(samples)
-            self.get_logger().info(f'battery_charging_state → slope={slope:.6f} V/s')
-            response.battery_charging_state = R.CHARGING if slope > 0.0 else R.NOT_CHARGING
+            return response
 
+        slope = self._l2_slope(samples)
+
+        if self._current_charging_state == R.NOT_CHARGING:
+            if slope > self._slope_threshold:
+                self._current_charging_state = R.CHARGING
+        else:  # currently CHARGING
+            if slope < -self._slope_threshold:
+                self._current_charging_state = R.NOT_CHARGING
+
+        self.get_logger().info(
+            f'battery_charging_state → slope={slope:.6f} V/s '
+            f'state={self._current_charging_state}'
+        )
+        response.battery_charging_state = self._current_charging_state
         return response
 
     # ------------------------------------------------------------------

--- a/vizzy_navigation/script/battery_state_simulator_service.py
+++ b/vizzy_navigation/script/battery_state_simulator_service.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+#
+# Copyright 2026, João Penha Lopes. All rights reserved.
 
 import rclpy
 from rclpy.node import Node

--- a/vizzy_navigation/script/battery_state_simulator_service.py
+++ b/vizzy_navigation/script/battery_state_simulator_service.py
@@ -28,7 +28,7 @@ from rclpy.node import Node
 from vizzy_msgs.srv import BatteryChargingState, BatteryState, SetBatteryState
 
 # Approximate percentage reported for each battery state.
-_STATE_PERCENTAGE = {0: 100.0, 1: 80.0, 2: 50.0, 3: 10.0}
+_STATE_PERCENTAGE = {0: 100, 1: 80, 2: 50, 3: 10}
 
 class BatterySimulatorService(Node):
 

--- a/vizzy_navigation/script/battery_state_simulator_service.py
+++ b/vizzy_navigation/script/battery_state_simulator_service.py
@@ -1,62 +1,79 @@
 #!/usr/bin/env python3
 #
 # Copyright 2026, João Penha Lopes. All rights reserved.
+#
+# Battery state simulator for Vizzy simulation.
+#
+# Serves two read services and one write service:
+#
+#   battery_charging_state (vizzy_msgs/srv/BatteryChargingState)
+#   - Used by the charging/docking system.
+#
+#   battery_state (vizzy_msgs/srv/BatteryState)
+#   - Used by patrol_node. Response includes battery_state (int) and
+#     percentage (float). States: 0=CHARGED, 1=GOOD, 2=UNKNOWN, 3=LOW_BATTERY.
+#
+#   set_battery_state (vizzy_msgs/srv/SetBatteryState)
+#   - External trigger. Call with battery_charging_state=3 to simulate
+#     a low-battery event and interrupt the patrol run:
+#
+#       ros2 service call /set_battery_state vizzy_msgs/srv/SetBatteryState "{battery_charging_state: 3}"
+#
+#   Reset to GOOD (1) after the charge cycle completes:
+#
+#       ros2 service call /set_battery_state vizzy_msgs/srv/SetBatteryState "{battery_charging_state: 1}"
 
 import rclpy
 from rclpy.node import Node
-from vizzy_msgs.srv import BatteryChargingState, SetBatteryState
+from vizzy_msgs.srv import BatteryChargingState, BatteryState, SetBatteryState
 
-class BatteryChargingService(Node):
+# Approximate percentage reported for each battery state.
+_STATE_PERCENTAGE = {0: 100.0, 1: 80.0, 2: 50.0, 3: 10.0}
+
+class BatterySimulatorService(Node):
+
     def __init__(self):
         super().__init__('battery_charging_service')
 
-        self.declare_parameter('initial_battery_state', 0)  # Default to 0 (NOT_CHARGING).
-        
-        # Initialize the battery state.
+        self.declare_parameter('initial_battery_state', 1)  # Default: GOOD.
+
         initial_state = self.get_parameter('initial_battery_state').get_parameter_value().integer_value
         self.battery_state = initial_state
-        self.get_logger().info(f"Setting initial battery state to: {self.battery_state}")
+        self.get_logger().info(f'Initial battery state: {self.battery_state}')
 
-        # Service 1: Returns the current battery state
-        self.get_state_srv = self.create_service(
-            BatteryChargingState,
-            'battery_charging_state',
-            self.handle_get_state_request
-        )
+        self.create_service(BatteryChargingState, 'battery_charging_state',
+                            self._handle_get_charging_state)
+        self.create_service(BatteryState,         'battery_state',
+                            self._handle_get_battery_state)
+        self.create_service(SetBatteryState,      'set_battery_state',
+                            self._handle_set_state)
 
-        # Service 2: Sets the battery state from an external call
-        self.set_state_srv = self.create_service(
-            SetBatteryState,
-            'set_battery_state',
-            self.handle_set_state_request
-        )
-        
-        self.get_logger().info("Battery service server is ready.")
+        self.get_logger().info('Battery simulator ready. '
+                               'Call /set_battery_state with state=3 to trigger low-battery.')
 
-    def handle_get_state_request(self, request, response):
-        """
-        Handles requests to get the current battery charging state.
-        The 'request' object for this service is empty.
-        """
+    def _handle_get_charging_state(self, request, response):
         response.battery_charging_state = self.battery_state
-        self.get_logger().info(f"Received GET request. Responding with state: {self.battery_state}")
         return response
 
-    def handle_set_state_request(self, request, response):
-        """
-        Handles requests to set the current battery charging state.
-        The 'request' object contains a uint8 with the new state.
-        """
+    def _handle_get_battery_state(self, request, response):
+        response.battery_state = self.battery_state
+        response.percentage    = _STATE_PERCENTAGE.get(self.battery_state, 50.0)
+        return response
+
+    def _handle_set_state(self, request, response):
+        old = self.battery_state
         self.battery_state = request.battery_charging_state
         response.success = True
-        self.get_logger().info(f"Received SET request. New battery state is: {self.battery_state}")
+        self.get_logger().info(f'Battery state changed: {old} -> {self.battery_state} '
+                               f'({_STATE_PERCENTAGE.get(self.battery_state, 50.0):.0f}%)')
         return response
+
 
 def main(args=None):
     rclpy.init(args=args)
-    battery_charging_service = BatteryChargingService()
-    rclpy.spin(battery_charging_service)
+    rclpy.spin(BatterySimulatorService())
     rclpy.shutdown()
+
 
 if __name__ == '__main__':
     main()

--- a/vizzy_navigation/script/patrol_node.py
+++ b/vizzy_navigation/script/patrol_node.py
@@ -70,6 +70,14 @@ class PatrolNode(Node):
         self._active_goal_handle = None
         self._goal_lock          = threading.Lock()
 
+        # Manual docking control. _dock_requested asks the patrol loop to dock
+        # and hold (regardless of battery); _resume_requested releases the hold.
+        # See the dock_now / resume_patrol services below.
+        self._dock_requested   = threading.Event()
+        self._resume_requested = threading.Event()
+        self.create_service(Trigger, 'dock_now',      self._on_dock_now)
+        self.create_service(Trigger, 'resume_patrol', self._on_resume_patrol)
+
         self._patrol_thread = threading.Thread(target=self._patrol_loop, daemon=True)
         self._patrol_thread.start()
 
@@ -313,6 +321,65 @@ class PatrolNode(Node):
         self.get_logger().info('--- Charge cycle end ---')
 
     # ------------------------------------------------------------------
+    # Manual docking control
+    # ------------------------------------------------------------------
+
+    def _on_dock_now(self, request, response):
+        """Trigger service: dock now and hold, regardless of battery state.
+
+        Sets a flag the patrol loop acts on, and cancels any active waypoint
+        goal immediately so the robot stops patrolling without waiting for the
+        next battery-poll tick. The robot then docks and holds at the dock
+        until resume_patrol is called.
+        """
+        self.get_logger().info('Manual dock requested via dock_now service.')
+        self._dock_requested.set()
+        self._cancel_active_goal()
+        response.success = True
+        response.message = ('Dock request accepted. Robot will dock and hold '
+                            'until /resume_patrol is called.')
+        return response
+
+    def _on_resume_patrol(self, request, response):
+        """Trigger service: release a held dock and resume patrol (undocks)."""
+        self.get_logger().info('Resume requested via resume_patrol service.')
+        self._resume_requested.set()
+        response.success = True
+        response.message = ('Resume request accepted. Robot will undock (if '
+                            'holding at the dock) and resume patrol.')
+        return response
+
+    def _manual_dock_cycle(self) -> None:
+        """Dock on manual request and hold until resume_patrol is called.
+
+        Unlike _charge_cycle (battery-driven), this does not wait for battery
+        recovery and does not auto-undock; it parks at the dock until released.
+        """
+        self._dock_requested.clear()
+        self.get_logger().info('--- Manual dock cycle start (dock and hold) ---')
+
+        if not self._dock():
+            self.get_logger().error('Manual docking failed. Resuming patrol.')
+            return
+
+        # Discard any resume request that arrived before we finished docking.
+        self._resume_requested.clear()
+        self.get_logger().info('Docked. Holding until /resume_patrol is called.')
+
+        while rclpy.ok() and not self._resume_requested.is_set():
+            time.sleep(0.5)
+        if not rclpy.ok():
+            return
+        self._resume_requested.clear()
+
+        self.get_logger().info('Resuming: undocking...')
+        if not self._undock():
+            self.get_logger().error(
+                'Undocking failed. Manual intervention may be required.')
+
+        self.get_logger().info('--- Manual dock cycle end ---')
+
+    # ------------------------------------------------------------------
     # Main patrol loop
     # ------------------------------------------------------------------
 
@@ -323,7 +390,11 @@ class PatrolNode(Node):
         self._wait_for_nav2_active()
 
         while rclpy.ok():
-            # Pre-flight battery check before starting a new patrol run.
+            # Pre-flight checks before starting a new patrol run. A manual dock
+            # request takes priority over the battery check.
+            if self._dock_requested.is_set():
+                self._manual_dock_cycle()
+                continue
             if not self._battery_is_ok():
                 self._charge_cycle()
                 continue
@@ -339,10 +410,15 @@ class PatrolNode(Node):
 
             threading.Thread(target=_run, daemon=True).start()
 
-            # Poll battery concurrently while FollowWaypoints is executing.
+            # Poll battery and the manual-dock flag concurrently while
+            # FollowWaypoints is executing.
             battery_low = False
             while not patrol_done.wait(timeout=self._battery_check_period):
                 if not rclpy.ok():
+                    break
+                if self._dock_requested.is_set():
+                    # dock_now already cancelled the goal; just stop polling.
+                    self._cancel_active_goal()
                     break
                 if not self._battery_is_ok():
                     battery_low = True
@@ -351,7 +427,15 @@ class PatrolNode(Node):
 
             patrol_done.wait()  # ensure the action thread exits cleanly.
 
-            if battery_low:
+            # A manual dock request wins over the battery branch. It is the
+            # source of truth (set by the dock_now service), so check the flag
+            # directly rather than relying on the poll loop having caught it
+            # before FollowWaypoints finished cancelling.
+            if self._dock_requested.is_set():
+                self.get_logger().info(
+                    'Patrol interrupted: manual dock request. Docking and holding.')
+                self._manual_dock_cycle()
+            elif battery_low:
                 self.get_logger().info(
                     'Patrol interrupted: low battery. Starting charge cycle.')
                 self._charge_cycle()

--- a/vizzy_navigation/script/patrol_node.py
+++ b/vizzy_navigation/script/patrol_node.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026, João Penha Lopes. All rights reserved.
+#
+# Autonomous patrol node for Vizzy.
+#
+# Loops through a list of waypoints loaded from a YAML file using Nav2's
+# FollowWaypoints action. Monitors battery state between and during patrol runs.
+# When LOW_BATTERY is detected, Vizzy cancels the active navigation goal, executes the
+# existing charging procedure via the charge action server, waits for battery
+# recovery, undocks, then immediately resumes patrol from waypoint 0.
+#
+# Battery policy:
+#   - Real hardware: battery_state service MUST be available. The node blocks on
+#     startup if the service is not yet reachable and logs an error until it is.
+#   - Simulation (is_simulation=True): if battery_state service is unavailable,
+#     a warning is logged and patrol continues uninterrupted. This is an explicit
+#     fallback for simulation environments where a full battery service is not
+#     deployed. Use a separate mock battery_state service to test the charge branch.
+
+import threading
+import time
+import yaml
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from action_msgs.msg import GoalStatus
+from geometry_msgs.msg import PoseStamped
+from nav2_msgs.action import FollowWaypoints
+from std_srvs.srv import Trigger
+from vizzy_msgs.action import Charge
+from vizzy_msgs.srv import BatteryState
+
+
+class PatrolNode(Node):
+
+    _LOW_BATTERY = 3   # BatteryState.Response.LOW_BATTERY
+    _GOOD        = 1   # BatteryState.Response.GOOD
+    _CHARGED     = 0   # BatteryState.Response.CHARGED
+    # (state 2 is reserved for "UNKNOWN")
+
+    def __init__(self):
+        super().__init__('patrol_node')
+
+        # Declare and get parameters.
+        self.declare_parameter('waypoints_file', '')
+        self.declare_parameter('is_simulation', False)
+        self.declare_parameter('battery_check_period_s', 5.0)
+        waypoints_file             = self.get_parameter('waypoints_file').value
+        self._is_simulation        = self.get_parameter('is_simulation').value
+        self._battery_check_period = self.get_parameter('battery_check_period_s').value
+
+        self.get_logger().info(
+            f'Starting patrol_node '
+            f'[is_simulation={self._is_simulation}, '
+            f'battery_check_period={self._battery_check_period}s, '
+            f'waypoints_file={waypoints_file}]')
+
+        self._waypoints = self._load_waypoints(waypoints_file)
+
+        self._follow_wp_client    = ActionClient(self, FollowWaypoints, 'follow_waypoints')
+        self._charge_client       = ActionClient(self, Charge,           'charge')
+        self._battery_client      = self.create_client(BatteryState,    'battery_state')
+        self._nav2_active_client  = self.create_client(
+            Trigger, '/lifecycle_manager_navigation/is_active')
+
+        # Protected by _goal_lock. Holds the currently active action goal handle
+        # so it can be cancelled from the battery-monitor path.
+        self._active_goal_handle = None
+        self._goal_lock          = threading.Lock()
+
+        self._patrol_thread = threading.Thread(target=self._patrol_loop, daemon=True)
+        self._patrol_thread.start()
+
+    # ------------------------------------------------------------------
+    # Waypoint loading
+    # ------------------------------------------------------------------
+
+    def _load_waypoints(self, path: str) -> list:
+        if not path:
+            raise RuntimeError('waypoints_file parameter is empty. Cannot start patrol.')
+        try:
+            with open(path, 'r') as f:
+                data = yaml.safe_load(f)
+            poses = []
+            for wp in data['waypoints']:
+                pose = PoseStamped()
+                pose.header.frame_id   = wp['frame_id']
+                pose.pose.position.x   = float(wp['position']['x'])
+                pose.pose.position.y   = float(wp['position']['y'])
+                pose.pose.position.z   = float(wp['position']['z'])
+                pose.pose.orientation.x = float(wp['orientation']['x'])
+                pose.pose.orientation.y = float(wp['orientation']['y'])
+                pose.pose.orientation.z = float(wp['orientation']['z'])
+                pose.pose.orientation.w = float(wp['orientation']['w'])
+                poses.append(pose)
+            if not poses:
+                raise RuntimeError('waypoints list is empty in YAML file.')
+            self.get_logger().info(f'Loaded {len(poses)} waypoints from {path}')
+            return poses
+        except Exception as e:
+            self.get_logger().fatal(f'Failed to load waypoints from "{path}": {e}')
+            raise
+
+    # ------------------------------------------------------------------
+    # Nav2 readiness
+    # ------------------------------------------------------------------
+
+    def _wait_for_nav2_active(self) -> None:
+        """Block until the Nav2 lifecycle manager reports all nodes as active."""
+        self.get_logger().info('Waiting for Nav2 stack to become active...')
+        while rclpy.ok():
+            if not self._nav2_active_client.wait_for_service(timeout_sec=5.0):
+                self.get_logger().info(
+                    'lifecycle_manager_navigation/is_active not yet reachable, retrying...',
+                    throttle_duration_sec=10.0)
+                continue
+
+            future = self._nav2_active_client.call_async(Trigger.Request())
+            deadline = time.monotonic() + 3.0
+            while not future.done() and rclpy.ok() and time.monotonic() < deadline:
+                time.sleep(0.05)
+
+            if future.done() and future.result() is not None and future.result().success:
+                self.get_logger().info('Nav2 stack is active. Starting patrol.')
+                return
+
+            self.get_logger().info(
+                'Nav2 not yet active, retrying in 1 s...',
+                throttle_duration_sec=5.0)
+            time.sleep(1.0)
+
+    # ------------------------------------------------------------------
+    # Battery monitoring
+    # ------------------------------------------------------------------
+
+    def _battery_is_ok(self) -> bool:
+        """Return True if battery state is above LOW_BATTERY.
+
+        Real hardware: waits indefinitely for the service to appear, then
+        checks. A missing service is treated as a mission-blocking fault.
+        Simulation: if the service is unavailable, logs a warning and returns
+        True so patrol continues (explicit simulation-only fallback).
+        """
+        if not self._battery_client.service_is_ready():
+            if self._is_simulation:
+                self.get_logger().warn(
+                    'battery_state service unavailable in simulation — '
+                    'continuing patrol without battery check.',
+                    throttle_duration_sec=60.0)
+                return True
+            else:
+                self.get_logger().error(
+                    'battery_state service unavailable on real hardware. '
+                    'Blocking patrol until service appears...')
+                while rclpy.ok() and not self._battery_client.wait_for_service(timeout_sec=5.0):
+                    self.get_logger().error(
+                        'Still waiting for battery_state service...',
+                        throttle_duration_sec=10.0)
+                if not rclpy.ok():
+                    return True  # node is shutting down.
+
+        future = self._battery_client.call_async(BatteryState.Request())
+        deadline = time.monotonic() + 3.0
+        while not future.done() and rclpy.ok() and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        if not future.done() or future.result() is None:
+            self.get_logger().warn('battery_state call timed out.')
+            # Real hardware: conservative (treat as blocked).
+            return self._is_simulation
+
+        state = future.result().battery_state
+        pct   = future.result().percentage
+        if state == self._LOW_BATTERY:
+            self.get_logger().warn(
+                f'LOW BATTERY (state={state}, {pct}%). Interrupting patrol.')
+            return False
+        return True
+
+    def _wait_for_battery_ok(self) -> None:
+        """Block until battery state is CHARGED or GOOD.
+
+        Simulation: waits a fixed 15s to represent a charge event so the
+        docking branch can be tested without a full battery service.
+        Real hardware: polls the battery_state service every 30s.
+        """
+        if self._is_simulation:
+            self.get_logger().info(
+                'Simulation: waiting 15 s to simulate charging time.')
+            time.sleep(15.0)
+            return
+
+        self.get_logger().info('Waiting for battery to recover (CHARGED or GOOD)...')
+        while rclpy.ok():
+            future = self._battery_client.call_async(BatteryState.Request())
+            deadline = time.monotonic() + 5.0
+            while not future.done() and rclpy.ok() and time.monotonic() < deadline:
+                time.sleep(0.1)
+
+            if future.done() and future.result() is not None:
+                state = future.result().battery_state
+                pct   = future.result().percentage
+                self.get_logger().info(f'Battery: state={state}, {pct}%')
+                if state <= self._GOOD:  # CHARGED=0 or GOOD=1
+                    self.get_logger().info('Battery recovered. Ready to resume patrol.')
+                    return
+
+            time.sleep(30.0)
+
+    # ------------------------------------------------------------------
+    # Generic action helper
+    # ------------------------------------------------------------------
+
+    def _send_action_sync(self, client: ActionClient, goal, description: str):
+        """Send an action goal and block until result arrives.
+
+        Returns (GoalStatus code, result object) or (None, None) on failure.
+        The active goal handle is stored in self._active_goal_handle while the
+        goal is running so it can be cancelled externally.
+        """
+        if not client.wait_for_server(timeout_sec=10.0):
+            self.get_logger().error(f'{description}: action server not available.')
+            return None, None
+
+        done_event    = threading.Event()
+        result_holder = [None]
+
+        def on_goal_response(future):
+            handle = future.result()
+            if not handle.accepted:
+                self.get_logger().error(f'{description}: goal rejected.')
+                done_event.set()
+                return
+            with self._goal_lock:
+                self._active_goal_handle = handle
+            handle.get_result_async().add_done_callback(on_result)
+
+        def on_result(future):
+            result_holder[0] = future.result()
+            with self._goal_lock:
+                self._active_goal_handle = None
+            done_event.set()
+
+        client.send_goal_async(goal).add_done_callback(on_goal_response)
+        done_event.wait()
+
+        r = result_holder[0]
+        return (r.status if r else None), (r.result if r else None)
+
+    def _cancel_active_goal(self) -> None:
+        with self._goal_lock:
+            handle = self._active_goal_handle
+        if handle is not None:
+            self.get_logger().info('Cancelling active navigation goal (low battery).')
+            handle.cancel_goal_async()
+
+    # ------------------------------------------------------------------
+    # Navigation and charging
+    # ------------------------------------------------------------------
+
+    def _follow_waypoints(self) -> bool:
+        """Send all patrol waypoints to Nav2's FollowWaypoints action server."""
+        now = self.get_clock().now().to_msg()
+        stamped = []
+        for wp in self._waypoints:
+            p = PoseStamped()
+            p.header.frame_id = wp.header.frame_id
+            p.header.stamp    = now
+            p.pose            = wp.pose
+            stamped.append(p)
+
+        goal       = FollowWaypoints.Goal()
+        goal.poses = stamped
+
+        status, _ = self._send_action_sync(
+            self._follow_wp_client, goal, 'FollowWaypoints')
+        return status == GoalStatus.STATUS_SUCCEEDED
+
+    def _dock(self) -> bool:
+        goal      = Charge.Goal()
+        goal.goal = Charge.Goal.CHARGE
+        status, result = self._send_action_sync(self._charge_client, goal, 'Charge(CHARGE)')
+        if status == GoalStatus.STATUS_SUCCEEDED and result is not None:
+            return result.result == Charge.Result.CHARGE_SUCCESS
+        return False
+
+    def _undock(self) -> bool:
+        goal      = Charge.Goal()
+        goal.goal = Charge.Goal.STOP_CHARGE
+        status, result = self._send_action_sync(self._charge_client, goal, 'Charge(STOP_CHARGE)')
+        if status == GoalStatus.STATUS_SUCCEEDED and result is not None:
+            return result.result == Charge.Result.STOPPED
+        return False
+
+    def _charge_cycle(self) -> None:
+        self.get_logger().info('--- Charge cycle start ---')
+
+        if not self._dock():
+            self.get_logger().error(
+                'Docking failed. Skipping charge cycle and resuming patrol.')
+            return
+
+        self.get_logger().info('Docked. Waiting for battery to recover...')
+        self._wait_for_battery_ok()
+
+        self.get_logger().info('Undocking...')
+        if not self._undock():
+            self.get_logger().error(
+                'Undocking failed. Manual intervention may be required.')
+
+        self.get_logger().info('--- Charge cycle end ---')
+
+    # ------------------------------------------------------------------
+    # Main patrol loop
+    # ------------------------------------------------------------------
+
+    def _patrol_loop(self) -> None:
+        self.get_logger().info('Patrol loop started.')
+
+        # Wait for Nav2 to be active before starting patrol runs.
+        self._wait_for_nav2_active()
+
+        while rclpy.ok():
+            # Pre-flight battery check before starting a new patrol run.
+            if not self._battery_is_ok():
+                self._charge_cycle()
+                continue
+
+            self.get_logger().info('Starting patrol run...')
+
+            patrol_done      = threading.Event()
+            patrol_succeeded = [False]
+
+            def _run() -> None:
+                patrol_succeeded[0] = self._follow_waypoints()
+                patrol_done.set()
+
+            threading.Thread(target=_run, daemon=True).start()
+
+            # Poll battery concurrently while FollowWaypoints is executing.
+            battery_low = False
+            while not patrol_done.wait(timeout=self._battery_check_period):
+                if not rclpy.ok():
+                    break
+                if not self._battery_is_ok():
+                    battery_low = True
+                    self._cancel_active_goal()
+                    break
+
+            patrol_done.wait()  # ensure the action thread exits cleanly.
+
+            if battery_low:
+                self.get_logger().info(
+                    'Patrol interrupted: low battery. Starting charge cycle.')
+                self._charge_cycle()
+            elif patrol_succeeded[0]:
+                self.get_logger().info(
+                    'Patrol run complete. Immediately restarting from waypoint 0.')
+            else:
+                self.get_logger().warn(
+                    'FollowWaypoints returned non-success status. Retrying in 5 s.')
+                time.sleep(5.0)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    try:
+        node     = PatrolNode()
+        executor = rclpy.executors.MultiThreadedExecutor()
+        executor.add_node(node)
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        print(f'[patrol_node] Fatal error: {e}')
+    finally:
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/vizzy_navigation/script/patrol_node.py
+++ b/vizzy_navigation/script/patrol_node.py
@@ -358,13 +358,22 @@ class PatrolNode(Node):
         self._dock_requested.clear()
         self.get_logger().info('--- Manual dock cycle start (dock and hold) ---')
 
-        if not self._dock():
-            self.get_logger().error('Manual docking failed. Resuming patrol.')
-            return
+        # Run the docking maneuver, then hold regardless of whether charging is
+        # confirmed. A manual dock may be triggered with a near-full battery (no
+        # measurable charge slope) or just to test the maneuver, so we do not
+        # resume patrol on a "not charging" result the way the battery-driven
+        # cycle does. The robot stays parked until /resume_patrol is called.
+        if self._dock():
+            self.get_logger().info('Docked and charging confirmed.')
+        else:
+            self.get_logger().warn(
+                'Dock did not confirm charging (near-full battery or no contact). '
+                'Holding at the dock anyway. If the robot is NOT physically docked, '
+                'call /resume_patrol to release it.')
 
         # Discard any resume request that arrived before we finished docking.
         self._resume_requested.clear()
-        self.get_logger().info('Docked. Holding until /resume_patrol is called.')
+        self.get_logger().info('Holding at dock until /resume_patrol is called.')
 
         while rclpy.ok() and not self._resume_requested.is_set():
             time.sleep(0.5)

--- a/vizzy_navigation/script/patrol_node.py
+++ b/vizzy_navigation/script/patrol_node.py
@@ -261,7 +261,7 @@ class PatrolNode(Node):
         with self._goal_lock:
             handle = self._active_goal_handle
         if handle is not None:
-            self.get_logger().info('Cancelling active navigation goal (low battery).')
+            self.get_logger().info('Cancelling active navigation goal.')
             handle.cancel_goal_async()
 
     # ------------------------------------------------------------------

--- a/vizzy_navigation/src/charging_action_server.cpp
+++ b/vizzy_navigation/src/charging_action_server.cpp
@@ -27,16 +27,15 @@ void ChargingActionServer::goalCallback(const std::shared_ptr<rclcpp_action::Ser
         charging_state_client_->async_send_request(request,
             [this, goal_handle, result](rclcpp::Client<vizzy_msgs::srv::BatteryChargingState>::SharedFuture response)
         {
-            if (response.get()->battery_charging_state)
+            // Always perform the docking maneuver on a CHARGE request. We do NOT
+            // short-circuit on an "already charging" reading: for ~24 s after the
+            // robot leaves the dock, the Kokam slope window still holds charging
+            // samples and reports CHARGING, which would make a dock request succeed
+            // without ever docking (the robot just stops in place). The initial
+            // service response is therefore intentionally ignored.
             {
-                RCLCPP_INFO(this->get_logger(), "SUCCESS! Robot is already at the dock and charging.");
-                result->result = result->CHARGE_SUCCESS;
-                goal_handle->succeed(result);
-                return;
-            }
-            else
-            {
-                RCLCPP_INFO(this->get_logger(), "Robot is not charging. Delegating to Docking Mission BT...");
+                (void)response;
+                RCLCPP_INFO(this->get_logger(), "Proceeding to docking mission...");
 
                 // Define the staging pose for the mission. 
                 // * (-2.430 -1.849 1.535 usefull for VISLAB) 

--- a/vizzy_navigation/src/charging_action_server.cpp
+++ b/vizzy_navigation/src/charging_action_server.cpp
@@ -7,6 +7,10 @@
 
 #include "charging_action_server.h"
 
+#include <chrono>
+#include <future>
+#include <thread>
+
 void ChargingActionServer::goalCallback(const std::shared_ptr<rclcpp_action::ServerGoalHandle<vizzy_msgs::action::Charge>> goal_handle)
 {
     auto goal = goal_handle->get_goal();
@@ -101,25 +105,62 @@ void ChargingActionServer::goalCallback(const std::shared_ptr<rclcpp_action::Ser
                         return;
                     }
 
-                    // The BT succeeded, now we do the final verification.
+                    // The BT succeeded; the dock maneuver is complete.
                     RCLCPP_INFO(this->get_logger(), "Docking Mission completed. Verifying charging status...");
-                    auto final_request = std::make_shared<vizzy_msgs::srv::BatteryChargingState::Request>();
-                    charging_state_client_->async_send_request(final_request,
-                        [this, goal_handle, result](rclcpp::Client<vizzy_msgs::srv::BatteryChargingState>::SharedFuture final_response)
+
+                    if (is_simulation_)
+                    {
+                        RCLCPP_INFO(this->get_logger(), "Simulation mode: assuming charging after successful docking.");
+                        result->result = result->CHARGE_SUCCESS;
+                        goal_handle->succeed(result);
+                        return;
+                    }
+
+                    // On real hardware the Kokam service derives "charging" from a voltage
+                    // slope over a rolling ~24 s window (40 samples @ ~600 ms). Right after
+                    // docking that window is still full of pre-dock discharge samples, so an
+                    // immediate check always reads NOT_CHARGING. We poll with a settle time long
+                    // enough for the window to refill with post-connection samples before
+                    // concluding. Done in a detached thread so the executor stays free to
+                    // service the battery_charging_state responses we wait on.
+                    std::thread([this, goal_handle, result]()
+                    {
+                        // Timeout must exceed the Kokam slope window (~24 s) so the window can
+                        // fill with rising-voltage samples once the charger is connected.
+                        const int timeout_s = 35;
+                        const auto poll_period = std::chrono::seconds(3);
+                        const auto deadline = std::chrono::steady_clock::now() +
+                                              std::chrono::seconds(timeout_s);
+
+                        while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline)
                         {
-                            if (final_response.get()->battery_charging_state || is_simulation_)
+                            std::this_thread::sleep_for(poll_period);
+
+                            auto req = std::make_shared<vizzy_msgs::srv::BatteryChargingState::Request>();
+                            auto future = charging_state_client_->async_send_request(req).share();
+                            if (future.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
+                            {
+                                RCLCPP_WARN(this->get_logger(), "battery_charging_state call timed out; retrying...");
+                                continue;
+                            }
+
+                            if (future.get()->battery_charging_state)
                             {
                                 RCLCPP_INFO(this->get_logger(), "SUCCESS! Robot is now charging!");
                                 result->result = result->CHARGE_SUCCESS;
                                 goal_handle->succeed(result);
+                                return;
                             }
-                            else 
-                            {
-                                RCLCPP_ERROR(this->get_logger(), "FAILURE! Docking Mission succeeded, but robot is not charging.");
-                                result->result = result->CHARGE_FAILED;
-                                goal_handle->abort(result);
-                            }
-                        });
+
+                            RCLCPP_INFO(this->get_logger(),
+                                "Not charging yet; waiting for the battery slope window to fill...");
+                        }
+
+                        RCLCPP_ERROR(this->get_logger(),
+                            "FAILURE! Docking succeeded, but charging was not detected within %d s.", timeout_s);
+                        result->result = result->CHARGE_FAILED;
+                        goal_handle->abort(result);
+                    }).detach();
                 };
 
                 RCLCPP_INFO(this->get_logger(), "Sending docking mission goal to Nav2...");

--- a/vizzy_navigation/src/charging_action_server.cpp
+++ b/vizzy_navigation/src/charging_action_server.cpp
@@ -261,9 +261,12 @@ ChargingActionServer::ChargingActionServer(const rclcpp::NodeOptions & options) 
     // Get the parameter's value and store it in the member variable.
     docking_bt_selection_ = this->get_parameter("docking_bt_selection").as_int();
 
-    // Retrieve and set "staging_pose" parameter.
-    this->declare_parameter<std::string>("staging_pose", "-x -1.0 -y 0.0 -Y 0.0");
-    std::string staging_pose_str = this->get_parameter("staging_pose").as_string();
+    // Retrieve and set staging pose based on simulation mode.
+    this->declare_parameter<std::string>("staging_pose_simulation", "-x -1.0 -y 0.0 -Y 0.0");
+    this->declare_parameter<std::string>("staging_pose_real", "-x -1.0 -y 0.0 -Y 0.0");
+    std::string staging_pose_str = is_simulation_
+        ? this->get_parameter("staging_pose_simulation").as_string()
+        : this->get_parameter("staging_pose_real").as_string();
 
     // Parse the string to extract the three double values.
     std::istringstream iss(staging_pose_str);

--- a/vizzy_robot/launch/segway_base_launch.xml
+++ b/vizzy_robot/launch/segway_base_launch.xml
@@ -20,7 +20,7 @@
 
           <!-- Parameters -->
           <param name="interface_type" value="serial" />
-          <param name="serial_port" value="/dev/ttyUSB0" />
+          <param name="serial_port" value="/dev/segway_rmp" />
           <param name="frame_id" value="$(var base_frame_id)" />
           <param name="invert_linear_vel_cmds" value="false" />
           <param name="invert_angular_vel_cmds" value="false" />


### PR DESCRIPTION
### Summary
This PR migrates Vizzy's Kokam battery serial PCB service from ROS1 to ROS2, replacing
the original blocking C++ architecture with a non-blocking Python node backed by a
background thread. It exposes the same `battery_state` and `battery_charging_state`
services consumed by the charging action server. 
Also cleans up residual TEASER++ references left from the
previous PR and updates the setup documentation.

---

## What changed

### 1) Kokam battery service migration ROS1 -> ROS2 (`battery_kokam_service.py`)

The original ROS1 implementation (`battery-state-service.cpp` /
`battery-charging-state-service.cpp`) used two blocking service handlers.
`battery_charging_state` in particular performed 40 sequential serial round-trips on
every call (~24 seconds of blocking per request).

The ROS2 port redesigns the architecture:

- **Background thread:** A thread continuously polls the serial port at the same ~600 ms/sample
  rate and maintains a rolling deque of the last 40 samples. Both service handlers read
   from the shared buffer and return immediately, meaning the 24-second block is eliminated.
- **Hysteresis for charging state:** The rolling window produces spurious slopes from
  noise when voltage is flat (battery neither charging nor discharging). A symmetric dead-band (`slope_threshold = 0.001
  V/s`, ~2.5× the noise floor) prevents false `CHARGING`/`NOT_CHARGING` transitions on
  a static, uncharged battery.
- **Serial port resilience:** Consecutive `SerialException` / `termios.error` failures
  trigger a port reopen with a 5-second settle delay and buffer clear, so the node
  recovers from brief USB disconnects without stale data corrupting the slope estimate.

**Hardware note:** The Kokam PCB must be connected directly to a motherboard USB port.
USB hubs cause the FT232R to power-cycle every 10–25 seconds regardless of software
configuration.

### 2) Launch integration (`vizzy_real_launch.xml`)

- Added `use_battery_state_simulation` argument (default `false` for real robot).
- Conditionally launches `battery_kokam_service.py` (real hardware) or
  `battery_state_simulator_service.py` (simulation) based on that argument.
- Added `inter_cycle_delay` argument (default `0.0`) passed through to the node,
  allowing the polling rate to be tuned.

### 3) Build system (`CMakeLists.txt`, `package.xml`)

- Added `battery_kokam_service.py` and `battery_state_simulator_service.py` to the
  CMake install step so both scripts are discoverable as executables after `colcon build`.
- Added `python3-serial` execution dependency to `package.xml`.

### 4) TEASER++ cleanup

Removed residual `find_package(teaserpp)`, `ament_target_dependencies(... teaserpp)`,
`target_link_libraries(... teaserpp::...)` and the corresponding `#include` from
`dock_pose_estimator.h`, left over from the TEASER++ -> NDT migration in PR #6.

### 5) Documentation (`README.md`)

- Updated directory image.
- Added the `inter_cycle_delay` parameter.

---

## Compatibility notes

- `use_battery_state_simulation` defaults to `false` on the real robot launch. Pass
  `use_battery_state_simulation:=true` explicitly when running in simulation without
  the physical battery PCB connected.